### PR TITLE
Correctly run e2e tests on GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.3.4'
+          - "3.3"
 
     steps:
     - uses: actions/checkout@v4
@@ -19,5 +19,37 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run the tests
+    - name: Run the unit tests
       run: bundle exec rake
+
+
+  e2e:
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: cats_test
+        ports: ['3306:3306']
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    runs-on: ubuntu-latest
+    name: End to end tests (Ruby ${{ matrix.ruby }}, App ${{ matrix.app }})
+    strategy:
+      matrix:
+        ruby:
+          - "3.3"
+        app:
+          - "rails7.1_mysql8"
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sample_apps/${{ matrix.app }}/Gemfile
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run the e2e tests
+      run: "bundle exec rake e2e:${{ matrix.app }}"

--- a/Rakefile
+++ b/Rakefile
@@ -42,4 +42,4 @@ Pathname.glob("test/e2e/*").select(&:directory?).each do |dir|
   task e2e: "e2e:#{dir.basename}"
 end
 
-task default: %i[test e2e standard]
+task default: %i[test standard]

--- a/sample_apps/rails7.1_mysql8/Rakefile
+++ b/sample_apps/rails7.1_mysql8/Rakefile
@@ -4,3 +4,5 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+task test: "db:test:prepare"

--- a/sample_apps/rails7.1_mysql8/config/database.yml
+++ b/sample_apps/rails7.1_mysql8/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  host: localhost
+  host: 127.0.0.1
   flags:
     - MULTI_STATEMENTS
 


### PR DESCRIPTION
Because of how separate Gemfiles are required for each sample app, and due to how [ruby/setup-ruby](https://github.com/ruby/setup-ruby) is laid out, we need a globally-set `BUNDLE_GEMFILE` env var to use separate Gemfiles in the action.

This in turn means we need separate jobs to run each set of e2e tests, which will slow down builds, but hopefully not make them prohibitively expensive.

Finally, this sets up MySQL to run on the e2e container. We'll need to break this up further as we add tests against different services, but let's fix one thing at a time.
