### PR TITLE
Add unit tests for all the sinks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,31 @@ on:
 
 jobs:
   build:
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: cats_test
+        ports: ['3306:3306']
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:16
+        ports: ['5432:5432']
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: --mount type=tmpfs,destination=/var/lib/postgresql/data --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries=3
+
     runs-on: ubuntu-latest
     name: Build (Ruby ${{ matrix.ruby }})
     strategy:
       matrix:
         ruby:
           - "3.3"
+    env:
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: password
 
     steps:
     - uses: actions/checkout@v4
@@ -20,7 +39,9 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run the unit tests
-      run: bundle exec rake
+      run: bundle exec rake test
+    - name: Lint the code
+      run: bundle exec rake standard
 
 
   e2e:

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,12 @@ gemspec
 
 gem "rake", "~> 13.0"
 gem "minitest"
+gem "minitest-stub-const"
 gem "standard"
 gem "debug"
+
+# Gems we patch and require for testing
+gem "mysql2"
+gem "pg"
+gem "sqlite3", "~> 1.4"
+gem "trilogy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,9 @@ GEM
       nokogiri (>= 1.12.0)
     mini_portile2 (2.8.7)
     minitest (5.24.1)
+    minitest-stub-const (0.6)
     mutex_m (0.2.0)
+    mysql2 (0.5.6)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -69,6 +71,7 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.7)
     psych (5.1.2)
       stringio
     racc (1.8.1)
@@ -110,6 +113,9 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-arm64-darwin)
     standard (1.39.2)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -124,6 +130,7 @@ GEM
       rubocop-performance (~> 1.21.0)
     stringio (3.1.1)
     strscan (3.1.0)
+    trilogy (2.8.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -136,8 +143,13 @@ DEPENDENCIES
   aikido-firewall!
   debug
   minitest
+  minitest-stub-const
+  mysql2
+  pg
   rake (~> 13.0)
+  sqlite3 (~> 1.4)
   standard
+  trilogy
 
 BUNDLED WITH
    2.5.16

--- a/lib/aikido/firewall/sinks/pg.rb
+++ b/lib/aikido/firewall/sinks/pg.rb
@@ -3,9 +3,23 @@
 module Aikido::Firewall
   module Sinks
     module PG
-      [:sync_exec, :async_exec, :exec, :exec_params, :sync_exec_prepared, :sync_exec_params, :exec_prepared, :async_exec_prepared, :async_exec_params].each do |method|
+      %w[
+        send_query exec sync_exec async_exec
+        send_query_params exec_params sync_exec_params async_exec_params
+      ].each do |method|
         module_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{method}(query, *)
+            Vulnerabilities::SQLInjectionScanner.scan(query, dialect: :postgresql)
+            super
+          end
+        RUBY
+      end
+
+      %w[
+        send_prepare prepare async_prepare sync_prepare
+      ].each do |method|
+        module_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{method}(_, query, *)
             Vulnerabilities::SQLInjectionScanner.scan(query, dialect: :postgresql)
             super
           end

--- a/test/aikido/firewall/sinks/mysql2_test.rb
+++ b/test/aikido/firewall/sinks/mysql2_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "mysql2"
+require "aikido/firewall/sinks/mysql2"
+
+class Aikido::Firewall::Sinks::Mysql2Test < Minitest::Test
+  def setup
+    @db = Mysql2::Client.new(
+      host: ENV.fetch("MYSQL_HOST", "127.0.0.1"),
+      username: ENV.fetch("MYSQL_USERNAME", "root"),
+      password: ENV.fetch("MYSQL_PASSWORD", "")
+    )
+  end
+
+  test "scans queries via #query" do
+    mock = Minitest::Mock.new
+    mock.expect :scan, nil, [String], dialect: :mysql
+
+    Aikido::Firewall::Vulnerabilities.stub_const(:SQLInjectionScanner, mock) do
+      @db.query("SELECT 1")
+    end
+
+    assert_mock mock
+  end
+end

--- a/test/aikido/firewall/sinks/pg_test.rb
+++ b/test/aikido/firewall/sinks/pg_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "pg"
+require "aikido/firewall/sinks/pg"
+
+class Aikido::Firewall::Sinks::PGTest < Minitest::Test
+  def setup
+    @db = PG.connect(
+      host: ENV.fetch("POSTGRES_HOST", "127.0.0.1"),
+      user: ENV.fetch("POSTGRES_USERNAME", ENV["USER"]),
+      password: ENV.fetch("POSTGRES_PASSWORD", "password"),
+      dbname: ENV.fetch("POSTGRES_DATABASE", "postgres")
+    )
+  end
+
+  def with_mocked_scanner(&b)
+    mock = Minitest::Mock.new
+    mock.expect :scan, nil, [String], dialect: :postgresql
+
+    Aikido::Firewall::Vulnerabilities.stub_const(:SQLInjectionScanner, mock) do
+      yield mock
+    end
+  end
+
+  test "scans queries via #send_query" do
+    with_mocked_scanner do |mock|
+      @db.send_query("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #exec" do
+    with_mocked_scanner do |mock|
+      @db.exec("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #sync_exec" do
+    with_mocked_scanner do |mock|
+      @db.sync_exec("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #async_exec" do
+    with_mocked_scanner do |mock|
+      @db.async_exec("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #send_query_params" do
+    with_mocked_scanner do |mock|
+      @db.send_query_params("SELECT $1", ["1"])
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #exec_params" do
+    with_mocked_scanner do |mock|
+      @db.exec_params("SELECT $1", ["1"])
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #sync_exec_params" do
+    with_mocked_scanner do |mock|
+      @db.sync_exec_params("SELECT $1", ["1"])
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #async_exec_params" do
+    with_mocked_scanner do |mock|
+      @db.async_exec_params("SELECT $1", ["1"])
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #send_prepare" do
+    with_mocked_scanner do |mock|
+      @db.send_prepare("name", "SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #prepare" do
+    with_mocked_scanner do |mock|
+      @db.prepare("name", "SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #asyncprepare" do
+    with_mocked_scanner do |mock|
+      @db.async_prepare("name", "SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #sync_prepare" do
+    with_mocked_scanner do |mock|
+      @db.sync_prepare("name", "SELECT 1")
+
+      assert_mock mock
+    end
+  end
+end

--- a/test/aikido/firewall/sinks/sqlite3_test.rb
+++ b/test/aikido/firewall/sinks/sqlite3_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "sqlite3"
+require "aikido/firewall/sinks/sqlite3"
+
+class Aikido::Firewall::Sinks::SQLite3Test < Minitest::Test
+  def setup
+    @db = SQLite3::Database.new(":memory:")
+  end
+
+  def with_mocked_scanner(&b)
+    mock = Minitest::Mock.new
+    mock.expect :scan, nil, [String], dialect: :sqlite
+
+    Aikido::Firewall::Vulnerabilities.stub_const(:SQLInjectionScanner, mock) do
+      yield mock
+    end
+  end
+
+  test "scans queries via #execute" do
+    with_mocked_scanner do |mock|
+      @db.execute("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #execute2" do
+    with_mocked_scanner do |mock|
+      @db.execute2("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #execute_batch" do
+    with_mocked_scanner do |mock|
+      @db.execute_batch("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #execute_batch2" do
+    with_mocked_scanner do |mock|
+      @db.execute_batch2("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries made by a prepared statement" do
+    with_mocked_scanner do |mock|
+      @db.prepare("SELECT 1") do |statement|
+        statement.execute
+
+        assert_mock mock
+      end
+    end
+  end
+end

--- a/test/aikido/firewall/sinks/trilogy_test.rb
+++ b/test/aikido/firewall/sinks/trilogy_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "trilogy"
+require "aikido/firewall/sinks/trilogy"
+
+class Aikido::Firewall::Sinks::TrilogyTest < Minitest::Test
+  def setup
+    @db = Trilogy.new(
+      host: ENV.fetch("MYSQL_HOST", "127.0.0.1"),
+      username: ENV.fetch("MYSQL_USERNAME", "root"),
+      password: ENV.fetch("MYSQL_PASSWORD", "")
+    )
+  end
+
+  test "scans queries via #query" do
+    mock = Minitest::Mock.new
+    mock.expect :scan, nil, [String], dialect: :mysql
+
+    Aikido::Firewall::Vulnerabilities.stub_const(:SQLInjectionScanner, mock) do
+      @db.query("SELECT 1")
+    end
+
+    assert_mock mock
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "aikido/firewall"
 require "minitest/autorun"
+require "minitest/stub_const"
 require "pathname"
 require "debug"
 


### PR DESCRIPTION
This verifies that all the DB sinks we set up actually call the SQL injection scanner when making queries with all the methods that are exposed by the underlying library.

In some cases, like MySQL drivers, which only expose one method to make queries, the end to end tests are enough to have coverage for the entire sink. But SQLite and PostgreSQL provide several methods to query the DB, and the end to end tests only cover one of those.