### PR TITLE
Treat integers as number for OpenAPI schema

### DIFF
--- a/lib/aikido/zen/request/schema/builder.rb
+++ b/lib/aikido/zen/request/schema/builder.rb
@@ -68,8 +68,6 @@ module Aikido::Zen
           new(type: "boolean")
         when String
           new(type: "string")
-        when Integer
-          new(type: "integer")
         when Numeric
           new(type: "number")
         when Array

--- a/lib/aikido/zen/request/schema/definition.rb
+++ b/lib/aikido/zen/request/schema/definition.rb
@@ -65,11 +65,6 @@ module Aikido::Zen
         in {type: _}, {type: "null"}
           new(definition.merge(optional: true))
 
-        # number | integer => number
-        in [{type: "integer"}, {type: "number"}] |
-           [{type: "number"}, {type: "integer"}]
-          new(definition.merge(other.definition).merge(type: "number"))
-
         # x | y => [x, y] if x != y
         else
           left_type, right_type = definition[:type], other.definition[:type]

--- a/test/aikido/zen/event_test.rb
+++ b/test/aikido/zen/event_test.rb
@@ -203,7 +203,7 @@ class Aikido::Zen::EventTest < ActiveSupport::TestCase
                     "properties" => {
                       "name" => {"type" => "string"},
                       "email" => {"type" => "string"},
-                      "age" => {"type" => "integer", "optional" => true}
+                      "age" => {"type" => "number", "optional" => true}
                     }
                   }
                 }

--- a/test/aikido/zen/request/schema/builder_test.rb
+++ b/test/aikido/zen/request/schema/builder_test.rb
@@ -148,7 +148,7 @@ class Aikido::Zen::Request::Schema::BuilderTest < ActiveSupport::TestCase
         properties: {
           "bool" => schema(type: "boolean"),
           "num" => schema(type: "number"),
-          "int" => schema(type: "integer"),
+          "int" => schema(type: "number"), # we are treating int as number
           "str" => schema(type: "string"),
           "nil" => schema(type: "null")
         }
@@ -162,7 +162,7 @@ class Aikido::Zen::Request::Schema::BuilderTest < ActiveSupport::TestCase
 
       assert_schema builder, schema(
         type: "array",
-        items: schema(type: "integer")
+        items: schema(type: "number")
       )
     end
 
@@ -173,7 +173,7 @@ class Aikido::Zen::Request::Schema::BuilderTest < ActiveSupport::TestCase
 
       assert_schema builder, schema(
         type: "array",
-        items: schema(type: "integer")
+        items: schema(type: "number")
       )
     end
 
@@ -195,7 +195,7 @@ class Aikido::Zen::Request::Schema::BuilderTest < ActiveSupport::TestCase
         items: schema(
           type: "object",
           properties: {
-            id: schema(type: "integer")
+            id: schema(type: "number")
           }
         )
       )
@@ -214,7 +214,7 @@ class Aikido::Zen::Request::Schema::BuilderTest < ActiveSupport::TestCase
             items: schema(
               type: "object",
               properties: schema(
-                id: schema(type: "integer")
+                id: schema(type: "number")
               )
             )
           )
@@ -232,9 +232,9 @@ class Aikido::Zen::Request::Schema::BuilderTest < ActiveSupport::TestCase
       assert_schema builder, schema(
         type: "object",
         properties: {
-          one: schema(type: "integer"),
-          two: schema(type: "integer"),
-          three: schema(type: "integer")
+          one: schema(type: "number"),
+          two: schema(type: "number"),
+          three: schema(type: "number")
         }
       )
     end

--- a/test/aikido/zen/request/schema/definition_test.rb
+++ b/test/aikido/zen/request/schema/definition_test.rb
@@ -30,7 +30,7 @@ class Aikido::Zen::Request::Schema::DefinitionTest < ActiveSupport::TestCase
   end
 
   test "#merge primitive with itself results in the same type" do
-    ["null", "string", "number", "integer", "boolean"].each do |type|
+    ["null", "string", "number", "boolean"].each do |type|
       schema_1 = build_schema(type: type)
       schema_2 = build_schema(type: type)
 
@@ -85,18 +85,8 @@ class Aikido::Zen::Request::Schema::DefinitionTest < ActiveSupport::TestCase
     ), null | obj
   end
 
-  test "#merge integer with number results in number" do
-    integer = build_schema(type: "integer")
-    number = build_schema(type: "number")
-
-    assert_equal build_schema(type: "number"), integer | number
-    assert_equal build_schema(type: "number"), number | integer
-  end
-
   test "#merge primitive types results in a combined type" do
-    ["string", "number", "integer", "boolean"].combination(2) do |(left, right)|
-      next if [left, right].sort == ["integer", "number"] # covered by other test
-
+    ["string", "number", "boolean"].combination(2) do |(left, right)|
       left_type = build_schema(type: left)
       right_type = build_schema(type: right)
 
@@ -127,7 +117,7 @@ class Aikido::Zen::Request::Schema::DefinitionTest < ActiveSupport::TestCase
       properties: {"prop" => build_schema(type: "string")}
     )
 
-    ["string", "number", "integer", "boolean"].each do |type|
+    ["string", "number", "boolean"].each do |type|
       primitive = build_schema(type: type)
       expected = build_schema(
         type: ["object", type].sort,

--- a/test/aikido/zen/request_test.rb
+++ b/test/aikido/zen/request_test.rb
@@ -269,7 +269,7 @@ class Aikido::Zen::RequestTest < ActiveSupport::TestCase
                   "email" => {"type" => "string"},
                   "name" => {"type" => "string"},
                   "accepts_terms" => {"type" => "boolean"},
-                  "age" => {"type" => "integer"},
+                  "age" => {"type" => "number"},
                   "interests" => {
                     "type" => "array",
                     "items" => {"type" => "string"}


### PR DESCRIPTION
Internally, Aikido's backend treats `integer` as `number`, so it fails to generate the OpenAPI with the schema provided by ruby's agent