### PR TITLE
load agent after the sinks are loaded

### DIFF
--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -63,6 +63,7 @@ module Aikido::Zen
 
       # It's important we start after loading sinks, so we can report the installed packages
       Aikido::Zen.start!
+      Aikido::Zen.start!
 
       # Agent's bootstrap process has finished —Controllers are patched to block
       # unwanted requests, sinks are loaded, scanners are running—, so we mark


### PR DESCRIPTION
Otherwise we'll no have the packages when reporting to aikido's backend