### PR TITLE
removes micro optimization that provokes a scan recursion

### DIFF
--- a/lib/aikido/zen/request/rails_router.rb
+++ b/lib/aikido/zen/request/rails_router.rb
@@ -31,7 +31,6 @@ module Aikido::Zen
     private def recognize_in_route_set(request, route_set, prefix: nil)
       route_set.router.recognize(request) do |route, _|
         app = route.app
-        next unless app.matches?(request)
 
         if app.dispatcher?
           return build_route(route, request, prefix: prefix)


### PR DESCRIPTION
When calling `app.matches?(req)`, it potentially executes the rails route constraints. These constraints can be DB calls, which trigger a new scan, which needs the `route`. Due to this situation, we could end up in a infinite loop recursion