### PR TITLE
Fix find warnings

### DIFF
--- a/bin/link_gemfile
+++ b/bin/link_gemfile
@@ -29,7 +29,7 @@ link_gemfile_in_dir() {
 }
 
 link_gemfile_in_dir "$RUBY_VERSION" "."
-find "./sample_apps" -type d -mindepth 1 -maxdepth 1 |\
+find "./sample_apps" -mindepth 1 -maxdepth 1 -type d |\
   while IFS= read -r dir; do
     link_gemfile_in_dir "$RUBY_VERSION" "$dir";
   done


### PR DESCRIPTION
When `./bin/link_gemfile` is run find(1) outputs two warnings:

```
$ ./bin/link_gemfile
find: warning: you have specified the global option -mindepth after the argument -type, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
$
```

This commit moves the -mindepth and -maxdepth global options before the -type argument.