### PR TITLE
Add Ruby 3.4 Gemfiles

### DIFF
--- a/gemfiles/ruby-3.4.gemfile
+++ b/gemfiles/ruby-3.4.gemfile
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: "."
+
+gem "rake", "~> 13.0"
+gem "rack-test"
+gem "railties", ">= 6.1", "< 8"
+gem "actionpack"
+gem "activesupport"
+gem "minitest"
+gem "minitest-stub-const"
+gem "webmock", "~> 3.23"
+gem "standard"
+gem "debug"
+gem "puma"
+gem "yard"
+gem "simplecov", require: false
+
+##
+# Gems we patch and require for testing
+##
+
+# SQL Adapters
+gem "mysql2"
+gem "pg"
+gem "sqlite3", "~> 1.4"
+gem "trilogy"
+
+# HTTP clients
+gem "http", "~> 5.2"
+gem "httpx", "~> 1.3"
+gem "httpclient", "~> 2.8"
+gem "excon", "~> 0.111.0"
+gem "curb", "~> 1.0"
+gem "patron", "~> 0.13.3"
+gem "typhoeus", "~> 1.4"
+gem "async-http", "~> 0.75.0"
+gem "em-http-request", "~> 1.1"

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.4.gemfile
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.4.gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.1.3", ">= 7.1.3.4"
+gem "sprockets-rails"
+gem "puma"
+gem "tzinfo-data", platforms: %i[windows jruby]
+
+group :development, :test do
+  gem "debug", platforms: %i[mri windows]
+  gem "standard"
+end
+
+gem "aikido-zen", path: "../.."

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.4.gemfile
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.4.gemfile
@@ -1,0 +1,19 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.1.3", ">= 7.1.3.4"
+gem "sprockets-rails"
+gem "puma"
+gem "tzinfo-data", platforms: %i[windows jruby]
+
+# We want to run the SQL Injection tests against all DBs
+gem "sqlite3", "~> 1.4"
+gem "mysql2"
+gem "trilogy"
+gem "pg"
+
+group :development, :test do
+  gem "debug", platforms: %i[mri windows]
+  gem "standard"
+end
+
+gem "aikido-zen", path: "../.."


### PR DESCRIPTION
This commit follows the apparent pattern of creating Gemfiles to support a Ruby version by duplicating the Gemfiles of an already supported Ruby version. This is the minimum required to support a Ruby version.