### PR TITLE
Correct benchmark run instructions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,11 +13,11 @@ In order to run a benchmarks against a single application, run the following
 from the root of the project:
 
 ```
-$ bundle exec rake bench:{app}:(k6|wrk)_run
+$ BUNDLE_GEMFILE=./sample_apps/{app}/Gemfile bundle exec rake bench:{app}:(k6|wrk)_run
 ```
 
 For example, for the WRK of `rails7.1_benchmark` application:
 
 ```
-$ bundle exec rake bench:rails7.1_benchmark:wrk_run
+$ BUNDLE_GEMFILE=./sample_apps/rails7.1_benchmark/Gemfile bundle exec rake bench:rails7.1_benchmark:wrk_run
 ```


### PR DESCRIPTION
The BUNDLE_GEMFILE environment variable must be set to the Gemfile of the sample application that the benchmark is being run against for Ruby to find the required modules, for the `rails server` to boot.

This requirement should be satisfied internally in the future. 