### PR TITLE
Disable throttling if rate limiting is disabled on the requested route in the runtime settings

### DIFF
--- a/lib/aikido/zen/middleware/rack_throttler.rb
+++ b/lib/aikido/zen/middleware/rack_throttler.rb
@@ -33,6 +33,7 @@ module Aikido::Zen
       private
 
       def should_throttle?(request)
+        return false unless @settings.endpoints[request.route].rate_limiting.enabled?
         return false if @settings.skip_protection_for_ips.include?(request.ip)
 
         result = @detached_agent.calculate_rate_limits(request)

--- a/lib/aikido/zen/sinks/action_controller.rb
+++ b/lib/aikido/zen/sinks/action_controller.rb
@@ -43,7 +43,8 @@ module Aikido::Zen
         end
 
         private def should_throttle?(request)
-          return false if Aikido::Zen.runtime_settings.skip_protection_for_ips.include?(request.ip)
+          return false unless @settings.endpoints[request.route].rate_limiting.enabled?
+          return false if @settings.skip_protection_for_ips.include?(request.ip)
 
           result = @detached_agent.calculate_rate_limits(request)
           return false unless result


### PR DESCRIPTION
This is intended to increase the benchmark success frequency, after the recent changes to `refactor-agent`, by avoiding an unnecessary DRb call to `Aikido::Zen::RateLimiter#calculate_rate_limits` if rate limiting is disabled on the requested route in the runtime settings. It presumes that accessing the runtime settings `Struct` does not itself require a DRb call to check the rate limiting state. The effect on the benchmark success frequency is in doubt since the benchmarks continue to fail.

It propagates the assumption that `@settings` is up to date (discussion is needed to understand whether this is the case, and further changes may be needed to ensure it is the case.)