### PR TITLE
Exclude EM-HTTP-Request tests on Ruby 3.4+

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -15,6 +15,12 @@ SimpleCov.start do
   minimum_coverage line: 95, branch: 85
 
   add_filter "/test/"
+
+  # WebMock excludes EM-HTTP-Request on Ruby 3.4:
+  # https://github.com/c960657/webmock/commit/34d16285dbcc574c90b273a89f16cb5fb9f4222a
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0") && Gem.loaded_specs["em-http-request"].version <= Gem::Version.new("1.1.7")
+    add_filter "lib/aikido/zen/sinks/em_http.rb"
+  end
 end
 
 # vim: ft=ruby

--- a/test/aikido/zen/sinks/em_http_test.rb
+++ b/test/aikido/zen/sinks/em_http_test.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# WebMock excludes EM-HTTP-Request on Ruby 3.4:
+# https://github.com/c960657/webmock/commit/34d16285dbcc574c90b273a89f16cb5fb9f4222a
+return if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0") && Gem.loaded_specs["em-http-request"].version <= Gem::Version.new("1.1.7")
+
 require "test_helper"
 
 class Aikido::Zen::Sinks::EmHttpRequestTest < ActiveSupport::TestCase


### PR DESCRIPTION
WebMock no longer patches EM-HTTP-Request <= 1.1.7 on Ruby >= 3.4.0, which causes the test suite to hang indefinitely, without modifications to the EM-HTTP-Request tests (which fail). This change does not modify the EM-HTTP-Request tests, but replicates WebMock's logic to exclude EM-HTTP-Request tests from execution and coverage for the affected versions. This change does not exclude our own patches to EM-HTTP-Request (which might still work, but require manual testing).