### PR TITLE
Fix File.new and File.open file tests

### DIFF
--- a/test/aikido/zen/sinks/file_test.rb
+++ b/test/aikido/zen/sinks/file_test.rb
@@ -9,21 +9,29 @@ class Aikido::Zen::Sinks::FileTest < ActiveSupport::TestCase
     include SinkAttackHelpers
 
     test "File.new" do
-      Helpers.temp_file_name do |tmp_file|
-        assert_nothing_raised do
-          tmp_file.new(tmp_file)
-          tmp_file.close
-        end
+      tmp_file_name = Helpers.temp_file_name
+      File.write(tmp_file_name, "")
+
+      tmp_file = nil
+      assert_nothing_raised do
+        tmp_file = File.new(tmp_file_name)
       end
+      tmp_file.close
+
+      File.unlink(tmp_file_name)
     end
 
     test "File.open" do
-      Helpers.temp_file_name do |tmp_file|
-        assert_nothing_raised do
-          tmp_file.open(tmp_file)
-          tmp_file.close
-        end
+      tmp_file_name = Helpers.temp_file_name
+      File.write(tmp_file_name, "")
+
+      tmp_file = nil
+      assert_nothing_raised do
+        tmp_file = File.open(tmp_file_name)
       end
+      tmp_file.close
+
+      File.unlink(tmp_file_name)
     end
 
     test "File.read" do


### PR DESCRIPTION
The tests for `File.new` and `File.open` do not test these methods, because `Helpers.temp_file_name` does not yield to the block argument provided. If that block argument was called, these file tests would also test the `File#close` method.

This change rewrites the tests for `File.new` and `File.open` to exclusively test their one method; `File#close` is not tested in either of these file tests.