### PR TITLE
Disable Bundler frozen mode in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
       contents: write
       id-token: write
 
+    env:
+      BUNDLE_FROZEN: false
+
     needs:
       - build
     steps:


### PR DESCRIPTION
Fix the release workflow by disabling Bundler frozen mode; this is not really recommended, but it aligns with the workflow for other Zen implementations.

As part of the new release process we replace the version placeholder in `./lib/aikido/zen/version.rb` to set `VERSION` from the Git tag name of the release. This change to the source code causes Bundler to complain that the version of `aikido-zen` (used by the `sample_apps`) has changed and that the `Gemfile.lock` needs to be updated.

As this is the intended behavior, it is permissible to disable Bundler frozen mode to relaxes these checks.

Setting `BUNDLE_FROZEN` to `false` should resolve this issue.