### PR TITLE
Prepare release 1.0.0-beta.1

### DIFF
--- a/gemfiles/ruby-2.7.gemfile.lock
+++ b/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.0.gemfile.lock
+++ b/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.1.gemfile.lock
+++ b/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.2.gemfile.lock
+++ b/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.3.gemfile.lock
+++ b/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/lib/aikido/zen/version.rb
+++ b/lib/aikido/zen/version.rb
@@ -2,7 +2,7 @@
 
 module Aikido
   module Zen
-    VERSION = "0.1.1"
+    VERSION = "1.0.0-beta.1"
 
     # The version of libzen_internals that we build against.
     LIBZEN_VERSION = "0.1.37"

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (0.1.1)
+    aikido-zen (1.0.0.pre.beta.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack


### PR DESCRIPTION
This change adds the missing Gemfile.lock files for the `rails7.1_path_traversal` sample application before bumping the `VERSION` to `1.0.0-beta.1` in `lib/aikido/zen/version.rb` and the tracked Gemfile.lock files.