### PR TITLE
Ensure app.config.zen.logger is tagged

### DIFF
--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -33,7 +33,9 @@ module Aikido::Zen
     initializer "aikido.configuration" do |app|
       # Allow the logger to be configured before checking if disabled? so we can
       # let the user know that the agent is disabled.
-      app.config.zen.logger = ::Rails.logger.tagged("aikido")
+      logger = ::Rails.logger
+      logger = ActiveSupport::TaggedLogging.new(logger) unless logger.respond_to?(:tagged)
+      app.config.zen.logger = logger.tagged("aikido")
 
       next if config.zen.disabled?
 


### PR DESCRIPTION
If an application has been configured to use a non-default logger that does not respond to `tagged` the `::Rails.logger` is wrapped in a `ActiveSupport::TaggedLogging` in order for `app.config.zen.logger` output to be tagged as from "aikido".