### PR TITLE
Add security placeholder

### DIFF
--- a/placeholder/.gitignore
+++ b/placeholder/.gitignore
@@ -1,0 +1,2 @@
+*.gemspec
+*.gem

--- a/placeholder/README.md
+++ b/placeholder/README.md
@@ -1,0 +1,11 @@
+# Security Placeholder
+
+This gem has been published by [Aikido Security](https://aikido.dev) to help prevent supply chain attacks and protect the integrity of the Ruby ecosystem.
+
+It is **not intended for direct use** and contains no functional code.
+
+If you are looking for the actual library, please use [`aikido-zen`](https://rubygems.org/gems/aikido-zen).
+
+---
+
+This package exists solely for security purposes. For more information, visit [aikido.dev](https://aikido.dev).

--- a/placeholder/Rakefile
+++ b/placeholder/Rakefile
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rake"
+require "rake/clean"
+require "rubygems/package"
+
+GEM_NAMES = %w[aikido aikidozen]
+
+# Clean up generated gemspec and gem files
+CLEAN.include(*GEM_NAMES.map { |name| "#{name}.gemspec" })
+CLOBBER.include(*GEM_NAMES.map { |name| "#{name}-*.gem" })
+
+namespace :build do
+  GEM_NAMES.each do |gem_name|
+    gemspec_path = "#{gem_name}.gemspec"
+
+    # Generate gemspec from template if needed
+    file gemspec_path => ["aikido-zen.gemspec.template"] do
+      template = File.read("aikido-zen.gemspec.template")
+      content = template.gsub("@GEM_NAME", gem_name)
+      File.write(gemspec_path, content)
+      puts "Generated #{gemspec_path}"
+    end
+
+    desc "Build the #{gem_name} gem"
+    task gem_name => [gemspec_path] do
+      gemspec = Gem::Specification.load(gemspec_path)
+      raise "Failed to load gemspec: #{gemspec_path}" unless gemspec
+
+      gem_path = Gem::Package.build(gemspec)
+      puts "Built #{gem_path}"
+    end
+  end
+
+  desc "Build all gems"
+  task all: GEM_NAMES.map { |gem_name| "build:#{gem_name}" }
+end
+
+namespace :release do
+  GEM_NAMES.each do |gem_name|
+    gemspec_path = "#{gem_name}.gemspec"
+
+    desc "Build and publish the #{gem_name} to RubyGems"
+    task gem_name => ["build:#{gem_name}"] do
+      gemspec = Gem::Specification.load(gemspec_path)
+      raise "Failed to load gemspec: #{gemspec_path}" unless gemspec
+
+      gem_path = "#{gemspec.name}-#{gemspec.version}.gem"
+
+      puts "Publishing #{gem_path} to RubyGem..."
+      sh "gem push #{gem_path}"
+    end
+  end
+
+  desc "Build and publish all gems to RubyGems"
+  task all: GEM_NAMES.map { |gem_name| "release:#{gem_name}" }
+end

--- a/placeholder/aikido-zen.gemspec.template
+++ b/placeholder/aikido-zen.gemspec.template
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "@GEM_NAME"
+  spec.version = "0.0.1"
+  spec.authors = ["Aikido Security"]
+  spec.email = ["support@aikido.dev"]
+  spec.summary = "Security placeholder published by Aikido Security."
+  spec.description = "This gem has been published by Aikido Security to help prevent supply chain attacks. It is not intended for direct use. Please use 'aikido-zen' instead."
+  spec.homepage = "https://aikido.dev"
+  spec.license = "AGPL-3.0-or-later"
+
+  spec.required_ruby_version = ">= 2.3"
+
+  spec.files = Dir.glob("lib/**/*.rb") + ["README.md", "../LICENSE"]
+  spec.require_paths = ["lib"]
+end

--- a/placeholder/lib/aikido-zen.rb
+++ b/placeholder/lib/aikido-zen.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+raise LoadError, "This gem has been published by Aikido Security to help prevent supply chain attacks. It is not intended for direct use. Please use 'aikido-zen' instead."


### PR DESCRIPTION
To secure the Gem namespace and help prevent supply chain attacks.

The following placeholder `GEM_NAMES` are currently included at the top of the `Rakefile`:

* `aikido`
* `aikidozen`

Please propose any others that may be relevant or desirable i.e. I originally included `firewall-ruby` and `firewallruby`.

Note that the (unpublished) placeholder Gems built by the `Rakefile` include the Aikido commercial+AGPL `LICENSE` file. Please suggest another license to use (or none) if appropriate.

The placeholder Gems are intended to be build and published from a developers machine; not from the CI pipeline.