### PR TITLE
Prevent require "aikido"

### DIFF
--- a/lib/aikido.rb
+++ b/lib/aikido.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "aikido/zen"


### PR DESCRIPTION
Previously, it was possible to require `aikido-zen` as `aikido`, and this was the suggested completion from Ruby in `irb`. Together with #124, this change helps to prevent supply chain attacks by providing only one way to require `aikido-zen`:

```
require "aikido-zen"
```