### PR TITLE
Use rate limiting middleware

### DIFF
--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -14,6 +14,8 @@ module Aikido::Zen
 
       app.middleware.use Aikido::Zen::Middleware::SetContext
       app.middleware.use Aikido::Zen::Middleware::CheckAllowedAddresses
+      app.middleware.use Aikido::Zen::Middleware::RackThrottler
+
       # Request Tracker stats do not consider failed request or 40x, so the middleware
       # must be the last one wrapping the request.
       app.middleware.use Aikido::Zen::Middleware::RequestTracker


### PR DESCRIPTION
The rate limiting middleware was not being used automatically (but could be used manually). This change ensures that  the rate limiting middleware is used automatically, by adding it alongside the other middleware that is used automatically.