### PR TITLE
Conditionally enable protection

### DIFF
--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -31,7 +31,10 @@ module Aikido
     #
     # @return [void]
     def self.protect!
-      return if config.disabled?
+      if config.disabled?
+        config.logger.warn("Zen has been disabled and will not run.")
+        return
+      end
 
       # IMPORTANT: Any files that load sinks or start the Aikido Agent
       # should be required here only.

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -8,6 +8,12 @@ require_relative "context"
 
 module Aikido::Zen
   class Config
+    # @api private
+    # @return [Boolean] whether Aikido should protect.
+    def protect?
+      !api_token.nil? || blocking_mode? || debugging?
+    end
+
     # @return [Boolean] whether Aikido should be turned completely off (no
     #   intercepting calls to protect the app, no agent process running, no
     #   middleware installed). Defaults to false (so, enabled). Can be set

--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -10,7 +10,7 @@ module Aikido::Zen
     end
 
     initializer "aikido.add_middleware" do |app|
-      next if config.zen.disabled?
+      next unless config.zen.protect?
 
       app.middleware.use Aikido::Zen::Middleware::SetContext
       app.middleware.use Aikido::Zen::Middleware::CheckAllowedAddresses
@@ -37,8 +37,6 @@ module Aikido::Zen
       logger = ActiveSupport::TaggedLogging.new(logger) unless logger.respond_to?(:tagged)
       app.config.zen.logger = logger.tagged("aikido")
 
-      next if config.zen.disabled?
-
       app.config.zen.request_builder = Aikido::Zen::Context::RAILS_REQUEST_BUILDER
 
       # Plug Rails' JSON encoder/decoder, but only if the user hasn't changed
@@ -53,10 +51,7 @@ module Aikido::Zen
     end
 
     config.after_initialize do
-      if config.zen.disabled?
-        config.zen.logger.warn("Zen has been disabled and will not run.")
-        next
-      end
+      next unless config.zen.protect?
 
       # Make sure this is run at the end of the initialization process, so
       # that any gems required after aikido-zen are detected and patched


### PR DESCRIPTION
This change implements the same logic as `firewall-node`.

Protection is only enabled -- the sinks are only loaded and the agent is only started -- when one of these conditions is met:

- An API token is provided
- Block is enabled
- Debug is enabled

This helps control the contexts in which `aikido-zen` activates, particularly when any of these conditions are met by setting any of these environment variables only for processes that `aikido-zen` should protect:

- `AIKIDO_TOKEN=<token>`
- `AIKIDO_BLOCK=true`
- `AIKIDO_DEBUG=true`

NOTE: It is possible to set these configuration options in Ruby, but these configuration options are shared by all processes that load the Ruby configuration. To avoid unexpected behavior, when configuring in Ruby, care should then be taken to otherwise control the contexts in which `aikido-zen` activates.