### PR TITLE
Fix broken routes

### DIFF
--- a/lib/aikido/zen/context/rails_request.rb
+++ b/lib/aikido/zen/context/rails_request.rb
@@ -12,7 +12,9 @@ module Aikido::Zen
 
   # @!visibility private
   Context::RAILS_REQUEST_BUILDER = ->(env) do
-    delegate = ActionDispatch::Request.new(env)
+    # Duplicate the Rack environment to prevent unexpected modifications from
+    # breaking Rails routing.
+    delegate = ActionDispatch::Request.new(env.dup)
     request = Aikido::Zen::Request.new(
       delegate, framework: "rails", router: Rails.router
     )

--- a/lib/aikido/zen/request/rails_router.rb
+++ b/lib/aikido/zen/request/rails_router.rb
@@ -29,6 +29,11 @@ module Aikido::Zen
     end
 
     private def recognize_in_route_set(request, route_set, prefix: nil)
+      # ActionDispatch::Journey::Router#recognize modifies the Rack environment.
+      # This is correct for Rails routing, but it is not expected to be used in
+      # Rack middleware, and using it here can break Rails routing.
+      #
+      # To avoid this, the Rack environment is duplicated when building request.
       route_set.router.recognize(request) do |route, _|
         app = route.app
         next unless app.matches?(request)


### PR DESCRIPTION
By duplicating the Rack environment when building Rails requests.

This change works around the current implementation of _check allowed addresses_ as Rack middleware that uses the Rails routing machinery; breaking Rails routing by modifying the Rack `env` and causing `ActionController::RouteError`s.

By duplicating the Rack environment we isolate that environment, improving robustness, by providing the Rails routing machinery with an isolated `env` (in an `ActionDispatch::Request`) that it can expect to own. Any/all changes made to the isolated `env` are discarded.

This work around might suggest that _check allowed addresses_ should follow _rate limiting_ and _user blocking_ up into the ActionController sink.