### PR TITLE
Conditionally use tagged logging

### DIFF
--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -34,8 +34,8 @@ module Aikido::Zen
       # Allow the logger to be configured before checking if disabled? so we can
       # let the user know that the agent is disabled.
       logger = ::Rails.logger
-      logger = ActiveSupport::TaggedLogging.new(logger) unless logger.respond_to?(:tagged)
-      app.config.zen.logger = logger.tagged("aikido")
+      logger = logger.tagged("aikido") if logger.respond_to?(:tagged)
+      app.config.zen.logger = logger
 
       app.config.zen.request_builder = Aikido::Zen::Context::RAILS_REQUEST_BUILDER
 


### PR DESCRIPTION
`ActiveSupport::TaggedLogging` has requirements for loggers that it wraps that the configured logger might not meet, because `::Rails.logger` can be configured to an arbitrary logger. Rather than working around all missing requirements, this change asks the logger for the `tagged` logger if possible. If this is not possible then the `::Rails.logger` is used as is, eschewing possible errors.