### PR TITLE
Alias set_user to track_user

### DIFF
--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -165,6 +165,11 @@ module Aikido
       end
     end
 
+    # Align with other Zen implementations, while keeping internal consistency.
+    class << self
+      alias_method :set_user, :track_user
+    end
+
     # Marks that the Zen middleware was installed properly
     # @return void
     def self.middleware_installed!


### PR DESCRIPTION
Users of other Zen implementations may expect to call `set_user` to set up user tracking. This change introduces `set_user` as an alias for `track_user`, and proposes to keep `track_user` for internal consistency; the method name prefix `track_` is used consistently to track e.g. requests, redirects, attacks, etc.