### PR TITLE
Fix File.join path traversal bypass

### DIFF
--- a/lib/aikido/zen/sinks/file.rb
+++ b/lib/aikido/zen/sinks/file.rb
@@ -18,11 +18,12 @@ module Aikido::Zen
         ::File.singleton_class.class_eval do
           extend Sinks::DSL
 
-          # Create a copy of the original method for internal use only to prevent
+          # Create a copy of the original methods for internal use only to prevent
           # recursion in PathTraversalScanner.
           #
-          # IMPORTANT: The alias must be created before the method is overridden.
+          # IMPORTANT: The aliases must be created before the method is overridden.
           alias_method :expand_path__internal_for_aikido_zen, :expand_path
+          alias_method :join__internal_for_aikido_zen, :join
 
           sink_before :open do |path|
             Helpers.scan(path, "open")


### PR DESCRIPTION
As documented, `File.join` accepts a variable number of positional string parameters, but, in practice, it accepts a variable number of positional possibly nested string array parameters:

https://ruby-doc.org/3.4.1/File.html#method-c-join

When encountered, `File.join` calls itself recursively with the possibly nested array parameter:

https://github.com/ruby/ruby/blob/dc555a48e750b4d50eb7a7000ca1bfb927fa9459/file.c#L5285

`File.join` does not normalize paths.

When the query parameter is an array the context will contain payloads for the individual array elements of the query parameter array but not the joined path returned by `File.join`.

This change proposes to add the joined path payload to the context, as a special case, so that the joined path is available when `Aikido::Zen::Scanners::PathTraversalScanner` scans the string result of `File.join`.