### PR TITLE
Support custom client IP header

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,12 @@
+# Proxy settings
+
+We'll automatically use the `x-forwarded-for` header to determine the client's IP address when behind a proxy.
+
+If you're publicly exposing your server without a load balancer in front of it, you should set the `AIKIDO_TRUST_PROXY` env var to `false` to ensure that the correct IP address is used. Otherwise, someone could potentially spoof their IP address by adding the above header and thus bypassing the rate limiting.
+
+If you need to use a different header to determine the client's IP address, you can set the `AIKIDO_CLIENT_IP_HEADER` environment variable to the name of that header. This will override the default `x-forwarded-for` header.
+
+```bash
+# For Fly.io Platform
+AIKIDO_CLIENT_IP_HEADER=HTTP_FLY_CLIENT_IP bin/rails server
+```

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,10 +1,8 @@
 # Proxy settings
 
-We'll automatically use the `x-forwarded-for` header to determine the client's IP address when behind a proxy.
+We'll automatically use the `HTTP_X_FORWARDED_FOR` header to determine the client's IP address when behind a trusted proxy.
 
-If you're publicly exposing your server without a load balancer in front of it, you should set the `AIKIDO_TRUST_PROXY` env var to `false` to ensure that the correct IP address is used. Otherwise, someone could potentially spoof their IP address by adding the above header and thus bypassing the rate limiting.
-
-If you need to use a different header to determine the client's IP address, you can set the `AIKIDO_CLIENT_IP_HEADER` environment variable to the name of that header. This will override the default `x-forwarded-for` header.
+If you need to use a different header to determine the client's IP address, you can set the `AIKIDO_CLIENT_IP_HEADER` environment variable to the name of that header. This will override the default `HTTP_X_FORWARDED_FOR` header.
 
 ```bash
 # For Fly.io Platform

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -61,7 +61,7 @@ module Aikido::Zen
     # @return [Logger]
     attr_reader :logger
 
-    # @return [string] Path of the socket where the detached agent will listen.
+    # @return [String] Path of the socket where the detached agent will listen.
     # By default, is stored under the root application path with file name
     # `aikido-detached-agent.sock`
     attr_accessor :detached_agent_socket_path
@@ -150,6 +150,9 @@ module Aikido::Zen
     #   allow known hosts that should be able to resolve to the IMDS service.
     attr_accessor :imds_allowed_hosts
 
+    # @return [String] environment specific HTTP header providing the client IP.
+    attr_accessor :client_ip_header
+
     def initialize
       self.disabled = read_boolean_from_env(ENV.fetch("AIKIDO_DISABLED", false))
       self.blocking_mode = read_boolean_from_env(ENV.fetch("AIKIDO_BLOCK", false))
@@ -163,8 +166,9 @@ module Aikido::Zen
       self.json_decoder = DEFAULT_JSON_DECODER
       self.debugging = read_boolean_from_env(ENV.fetch("AIKIDO_DEBUG", false))
       self.logger = Logger.new($stdout, progname: "aikido", level: debugging ? Logger::DEBUG : Logger::INFO)
-      self.max_performance_samples = 5000
       self.detached_agent_socket_path = ENV.fetch("AIKIDO_DETACHED_AGENT_SOCKET_PATH", DEFAULT_DETACHED_AGENT_SOCKET_PATH)
+      self.client_ip_header = ENV.fetch("AIKIDO_CLIENT_IP_HEADER", nil)
+      self.max_performance_samples = 5000
       self.max_compressed_stats = 100
       self.max_outbound_connections = 200
       self.max_users_tracked = 1000

--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -17,8 +17,9 @@ module Aikido::Zen
     # @see Aikido::Zen.track_user
     attr_accessor :actor
 
-    def initialize(delegate, framework:, router:)
+    def initialize(delegate, config = Aikido::Zen.config, framework:, router:)
       super(delegate)
+      @config = config
       @framework = framework
       @router = router
       @body_read = false
@@ -44,6 +45,10 @@ module Aikido::Zen
     #
     # @return [String] the IP address of the client making the request.
     def client_ip
+      return @client_ip if @client_ip
+
+      @client_ip = env[@config.client_ip_header] if @config.client_ip_header
+
       @client_ip ||= respond_to?(:remote_ip) ? remote_ip : ip
     end
 

--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -47,7 +47,14 @@ module Aikido::Zen
     def client_ip
       return @client_ip if @client_ip
 
-      @client_ip = env[@config.client_ip_header] if @config.client_ip_header
+      if @config.client_ip_header
+        value = env[@config.client_ip_header]
+        if Resolv::AddressRegex.match?(value)
+          @client_ip = value
+        else
+          @config.logger.warn("Invalid IP address in custom client IP header `#{@config.client_ip_header}`: `#{value}`")
+        end
+      end
 
       @client_ip ||= respond_to?(:remote_ip) ? remote_ip : ip
     end

--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -40,6 +40,13 @@ module Aikido::Zen
       @schema ||= Aikido::Zen::Request::Schema.build
     end
 
+    # @api private
+    #
+    # @return [String] the IP address of the client making the request.
+    def client_ip
+      @client_ip ||= respond_to?(:remote_ip) ? remote_ip : ip
+    end
+
     # Map the CGI-style env Hash into "pretty-looking" headers, preserving the
     # values as-is. For example, HTTP_ACCEPT turns into "Accept", CONTENT_TYPE
     # turns into "Content-Type", and HTTP_X_FORWARDED_FOR turns into
@@ -87,7 +94,7 @@ module Aikido::Zen
       {
         method: request_method.downcase,
         url: url,
-        ipAddress: ip,
+        ipAddress: client_ip,
         userAgent: user_agent,
         headers: normalized_headers.reject { |_, val| val.to_s.empty? },
         body: truncated_body,

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -17,6 +17,8 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 10, @config.api_timeouts[:write_timeout]
     assert_kind_of ::Logger, @config.logger
     refute @config.debugging
+    assert_equal "aikido-detached-agent.sock", @config.detached_agent_socket_path
+    assert_equal nil, @config.client_ip_header
     assert_equal 5000, @config.max_performance_samples
     assert_equal 100, @config.max_compressed_stats
     assert_equal 200, @config.max_outbound_connections
@@ -33,7 +35,6 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 20, @config.api_schema_collection_max_properties
     assert_equal ["metadata.google.internal", "metadata.goog"], @config.imds_allowed_hosts
     assert_equal false, @config.disabled
-    assert_equal "aikido-detached-agent.sock", @config.detached_agent_socket_path
   end
 
   test "can set AIKIDO_DISABLED to configure if the agent should be turned off" do

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -18,7 +18,7 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_kind_of ::Logger, @config.logger
     refute @config.debugging
     assert_equal "aikido-detached-agent.sock", @config.detached_agent_socket_path
-    assert_equal nil, @config.client_ip_header
+    assert_nil @config.client_ip_header
     assert_equal 5000, @config.max_performance_samples
     assert_equal 100, @config.max_compressed_stats
     assert_equal 200, @config.max_outbound_connections

--- a/test/aikido/zen/request_test.rb
+++ b/test/aikido/zen/request_test.rb
@@ -157,6 +157,17 @@ class Aikido::Zen::RequestTest < ActiveSupport::TestCase
       assert_equal "1.2.3.4", req.as_json[:ipAddress]
     end
 
+    test "#as_json includes the remote IP from the custom client IP header" do
+      Aikido::Zen.config.client_ip_header = "HTTP_CUSTOM_CLIENT_IP"
+
+      env = Rack::MockRequest.env_for("/test", "REMOTE_ADDR" => "1.2.3.4", "HTTP_CUSTOM_CLIENT_IP" => "4.3.2.1")
+      req = build_request(env)
+
+      assert_equal "4.3.2.1", req.as_json[:ipAddress]
+
+      Aikido::Zen.config.client_ip_header = nil
+    end
+
     test "#as_json includes the User-Agent" do
       env = Rack::MockRequest.env_for("/test", "HTTP_USER_AGENT" => "Some/UA")
       req = build_request(env)


### PR DESCRIPTION
This change allows a custom client IP header to be specified. If specified the value of the header is used as the `client_ip`, otherwise, Rails' application configurable `request.remote_ip` is preferred over Rack's globally configurable `request.ip`.

The custom client IP header can be specified by setting either the `AIKIDO_CLIENT_IP_HEADER` environment variable or the `Aikido::Zen.config.client_ip_header` configuration option.

This implementation leans on Rails and Rack to correctly specify the trusted proxies. Like Rails and Rack, the value of the header provided by the trusted proxy is treated as a string.