### PR TITLE
Align metadata with firewall-node

### DIFF
--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -67,7 +67,9 @@ module Aikido::Zen
       end
 
       def metadata
-        {filename: filepath}
+        {
+          filename: filepath
+        }
       end
 
       def humanized_name
@@ -133,7 +135,10 @@ module Aikido::Zen
       end
 
       def metadata
-        {sql: @query}
+        {
+          sql: @query,
+          dialect: @dialect
+        }
       end
 
       def exception(*)
@@ -165,7 +170,7 @@ module Aikido::Zen
 
       def metadata
         {
-          host: @request.uri.hostname,
+          hostname: @request.uri.hostname,
           port: @request.uri.port
         }
       end
@@ -200,7 +205,10 @@ module Aikido::Zen
       end
 
       def metadata
-        {}
+        {
+          hostname: @hostname,
+          privateIP: @address
+        }
       end
     end
   end

--- a/test/aikido/zen/attack_test.rb
+++ b/test/aikido/zen/attack_test.rb
@@ -58,7 +58,10 @@ module Aikido::Zen
         operation: @op,
         blocked: false,
         payload: @input.value,
-        metadata: {sql: @query},
+        metadata: {
+          sql: @query,
+          dialect: @dialect
+        },
         source: "routeParams",
         path: "id"
       }
@@ -78,7 +81,10 @@ module Aikido::Zen
         operation: @op,
         blocked: true,
         payload: @input.value,
-        metadata: {sql: @query},
+        metadata: {
+          sql: @query,
+          dialect: @dialect
+        },
         source: "routeParams",
         path: "id"
       }


### PR DESCRIPTION
This change adds metadata entries that are present in `firewall-node` but not get in `firewall-ruby`.