### PR TITLE
Stored SSRF feature flag

### DIFF
--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -207,7 +207,7 @@ module Aikido::Zen
       def metadata
         {
           hostname: @hostname,
-          privateIP: @address
+          resolvedIP: @address
         }
       end
     end

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -70,6 +70,9 @@ module Aikido::Zen
     attr_accessor :debugging
     alias_method :debugging?, :debugging
 
+    # @return [String] environment specific HTTP header providing the client IP.
+    attr_accessor :client_ip_header
+
     # @return [Integer] maximum number of timing measurements to keep in memory
     #   before compressing them.
     attr_accessor :max_performance_samples
@@ -146,12 +149,15 @@ module Aikido::Zen
     #   the server returns a 429 response.
     attr_accessor :server_rate_limit_deadline
 
+    # @return [Boolean] whether Aikido Zen should scan for stored SSSRF attacks.
+    #   Defaults to true. Can be set through AIKIDO_FEATURE_STORED_SSRF
+    #   environment variable.
+    attr_accessor :stored_ssrf
+    alias_method :stored_ssrf?, :stored_ssrf
+
     # @return [Array<String>] when checking for stored SSRF attacks, we want to
     #   allow known hosts that should be able to resolve to the IMDS service.
     attr_accessor :imds_allowed_hosts
-
-    # @return [String] environment specific HTTP header providing the client IP.
-    attr_accessor :client_ip_header
 
     def initialize
       self.disabled = read_boolean_from_env(ENV.fetch("AIKIDO_DISABLED", false))
@@ -183,6 +189,7 @@ module Aikido::Zen
       self.api_schema_max_samples = Integer(ENV.fetch("AIKIDO_MAX_API_DISCOVERY_SAMPLES", 10))
       self.api_schema_collection_max_depth = 20
       self.api_schema_collection_max_properties = 20
+      self.stored_ssrf = read_boolean_from_env(ENV.fetch("AIKIDO_FEATURE_STORED_SSRF", true))
       self.imds_allowed_hosts = ["metadata.google.internal", "metadata.goog"]
     end
 

--- a/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
@@ -33,7 +33,9 @@ module Aikido::Zen
       # @return [String, nil] either the offending address, or +nil+ if no
       #   address is deemed dangerous.
       def attack?
-        return false if @config.imds_allowed_hosts.include?(@hostname)
+        return unless @config.stored_ssrf? # Feature flag
+
+        return if @config.imds_allowed_hosts.include?(@hostname)
 
         @addresses.find do |candidate|
           DANGEROUS_ADDRESSES.any? { |address| address === candidate }

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -8,6 +8,7 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
   end
 
   test "default values" do
+    assert_equal false, @config.disabled
     assert_equal false, @config.blocking_mode
     assert_nil @config.api_token
     assert_equal URI("https://guard.aikido.dev"), @config.api_endpoint
@@ -31,10 +32,11 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 3600, @config.client_rate_limit_period
     assert_equal 100, @config.client_rate_limit_max_events
     assert_equal 1800, @config.server_rate_limit_deadline
+    assert_equal true, @config.collect_api_schema?
     assert_equal 20, @config.api_schema_collection_max_depth
     assert_equal 20, @config.api_schema_collection_max_properties
+    assert_equal true, @config.stored_ssrf?
     assert_equal ["metadata.google.internal", "metadata.goog"], @config.imds_allowed_hosts
-    assert_equal false, @config.disabled
   end
 
   test "can set AIKIDO_DISABLED to configure if the agent should be turned off" do
@@ -52,6 +54,12 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
   test "can set AIKIDO_FEATURE_COLLECT_API_SCHEMA to configure if the agent should collect API schema" do
     assert_boolean_env_var "AIKIDO_FEATURE_COLLECT_API_SCHEMA" do |config|
       config.collect_api_schema?
+    end
+  end
+
+  test "can set AIKIDO_FEATURE_STORED_SSRF to configure if the agent should scan for stored SSRF attacks" do
+    assert_boolean_env_var "AIKIDO_FEATURE_STORED_SSRF" do |config|
+      config.stored_ssrf?
     end
   end
 

--- a/test/aikido/zen/scanners/stored_ssrf_scanner_test.rb
+++ b/test/aikido/zen/scanners/stored_ssrf_scanner_test.rb
@@ -28,4 +28,13 @@ class Aikido::Zen::Scanners::StoredSSRFScannerTest < ActiveSupport::TestCase
     refute_attack "metadata.google.internal", ["169.254.169.254"]
     refute_attack "metadata.goog", ["169.254.169.254"]
   end
+
+  test "allows hostnames that are trying to access the IMDS service when the stored SSRF scanning is disabled" do
+    Aikido::Zen.config.stored_ssrf = false
+    refute_attack "trust-me-im-good.com", ["169.254.169.254"]
+    refute_attack "trust-me-im-good.com", ["fd00:ec2::254"]
+    refute_attack "trust-me-im-good.com", ["1.1.1.1", "169.254.169.254", "2.2.2.2"]
+  ensure
+    Aikido::Zen.config.stored_ssrf = true
+  end
 end


### PR DESCRIPTION
This change adds a feature flag that allows the stored SSRF scanning feature to be disabled. This feature flag is expected to be temporary and has been intentionally left undocumented.

The stored SSRF scanning feature remains enabled by default. Stored SSRF scanning can be disabled by setting the `Aikido::Zen.config.stored_ssrf` Ruby configuration option or the `AIKIDO_FEATURE_STORED_SSRF` environment variable to false.

NOTE: If the host is known and safe it is is possible and preferable to extend the `Aikido::Zen.config.imds_allowed_hosts` Ruby configuration option, leaving stored SSRF scanning enabled.

For example:

```ruby
# config/initializers/aikido.rb
if Rails.application.config.respond_to?(:zen)
  Rails.application.config.zen.blocking_mode = true
  Rails.application.config.zen.stored_ssrf = false
  # Rails.application.config.zen.imds_allowed_hosts.concat << "known_safe_hostname"
end
```

The resolved IP is now reported as resolvedIP instead of privateIP in the StoredSSRFAttack metadata.