### PR TITLE
Add Codecov to repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,15 @@ jobs:
         bundler-cache: true
     - name: Run the unit tests
       run: bundle exec rake test
+      env:
+          COVERAGE_OUTPUT_LCOV: true
+    - name: "Upload coverage"
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5
+      with:
+        files: ./coverage/lcov/firewall-ruby.lcov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        slug: AikidoSec/firewall-ruby
     - name: Lint the code
       run: bundle exec rake standard
     - name: Build the gem

--- a/.github/workflows/smoke_test_ffi.yml
+++ b/.github/workflows/smoke_test_ffi.yml
@@ -30,7 +30,7 @@ jobs:
           bundle config set build.mysql2 --with-opt-dir=$(brew --prefix zstd)
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        run: "sudo apt-get install libmysqlclient-dev libpq-dev libcurl4-openssl-dev"
+        run: "sudo apt-get update && sudo apt-get install libmysqlclient-dev libpq-dev libcurl4-openssl-dev"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.simplecov
+++ b/.simplecov
@@ -6,6 +6,12 @@
 return if RUBY_VERSION < "3.0"
 return if ENV["DISABLE_COVERAGE"] == "true"
 
+# Output coverage as LCOV to support CodeCov
+if ENV["COVERAGE_OUTPUT_LCOV"] == "true"
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+end
+
 SimpleCov.start do
   # Make sure SimpleCov waits until after the tests
   # are finished to generate the coverage reports.

--- a/gemfiles/ruby-3.0.gemfile
+++ b/gemfiles/ruby-3.0.gemfile
@@ -17,6 +17,7 @@ gem "debug"
 gem "puma"
 gem "yard"
 gem "simplecov", require: false
+gem "simplecov-lcov", "~> 0.9.0", require: false
 
 ##
 # Gems we patch and require for testing

--- a/gemfiles/ruby-3.0.gemfile.lock
+++ b/gemfiles/ruby-3.0.gemfile.lock
@@ -178,6 +178,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
@@ -235,6 +236,7 @@ DEPENDENCIES
   railties (~> 7.1.0)
   rake (~> 13.0)
   simplecov
+  simplecov-lcov (~> 0.9.0)
   sqlite3 (~> 1.4)
   standard
   trilogy

--- a/gemfiles/ruby-3.1.gemfile
+++ b/gemfiles/ruby-3.1.gemfile
@@ -17,6 +17,7 @@ gem "debug"
 gem "puma"
 gem "yard"
 gem "simplecov", require: false
+gem "simplecov-lcov", "~> 0.9.0", require: false
 
 ##
 # Gems we patch and require for testing

--- a/gemfiles/ruby-3.1.gemfile.lock
+++ b/gemfiles/ruby-3.1.gemfile.lock
@@ -215,6 +215,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
@@ -274,6 +275,7 @@ DEPENDENCIES
   railties (>= 6.1, < 8)
   rake (~> 13.0)
   simplecov
+  simplecov-lcov (~> 0.9.0)
   sqlite3 (~> 1.4)
   standard
   trilogy

--- a/gemfiles/ruby-3.2.gemfile
+++ b/gemfiles/ruby-3.2.gemfile
@@ -17,6 +17,7 @@ gem "debug"
 gem "puma"
 gem "yard"
 gem "simplecov", require: false
+gem "simplecov-lcov", "~> 0.9.0", require: false
 
 ##
 # Gems we patch and require for testing

--- a/gemfiles/ruby-3.2.gemfile.lock
+++ b/gemfiles/ruby-3.2.gemfile.lock
@@ -215,6 +215,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
@@ -274,6 +275,7 @@ DEPENDENCIES
   railties (>= 6.1, < 8)
   rake (~> 13.0)
   simplecov
+  simplecov-lcov (~> 0.9.0)
   sqlite3 (~> 1.4)
   standard
   trilogy

--- a/gemfiles/ruby-3.3.gemfile
+++ b/gemfiles/ruby-3.3.gemfile
@@ -17,6 +17,7 @@ gem "debug"
 gem "puma"
 gem "yard"
 gem "simplecov", require: false
+gem "simplecov-lcov", "~> 0.9.0", require: false
 
 ##
 # Gems we patch and require for testing

--- a/gemfiles/ruby-3.3.gemfile.lock
+++ b/gemfiles/ruby-3.3.gemfile.lock
@@ -216,6 +216,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
@@ -276,6 +277,7 @@ DEPENDENCIES
   railties (>= 6.1, < 8)
   rake (~> 13.0)
   simplecov
+  simplecov-lcov (~> 0.9.0)
   sqlite3 (~> 1.4)
   standard
   trilogy

--- a/gemfiles/ruby-3.4.gemfile
+++ b/gemfiles/ruby-3.4.gemfile
@@ -17,6 +17,7 @@ gem "debug"
 gem "puma"
 gem "yard"
 gem "simplecov", require: false
+gem "simplecov-lcov", "~> 0.9.0", require: false
 
 ##
 # Gems we patch and require for testing

--- a/gemfiles/ruby-3.4.gemfile.lock
+++ b/gemfiles/ruby-3.4.gemfile.lock
@@ -233,6 +233,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
@@ -293,6 +294,7 @@ DEPENDENCIES
   railties (>= 6.1, < 8)
   rake (~> 13.0)
   simplecov
+  simplecov-lcov (~> 0.9.0)
   sqlite3 (~> 1.4)
   standard
   trilogy

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 require "bundler"
 Bundler.setup
 
+require "simplecov-lcov" if RUBY_VERSION >= "3"
 require "simplecov"
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)


### PR DESCRIPTION
As Codecov can't parse the default html or json output of simplecov, this uses the simplecov-lcov reporter, as recommended in the [Codecov docs](https://docs.codecov.com/docs/supported-report-formats#ruby)

+ Add missing `apt update` to smoke test