### PR TITLE
Make logger reconfiguration explicit

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -102,7 +102,6 @@ way.
 
 ## Logging
 
-By default, Zen will use the Rails logger, prefixing messages with `[aikido]`.
 You can redirect the log to a separate stream by overriding the logger:
 
 ```ruby
@@ -110,5 +109,5 @@ You can redirect the log to a separate stream by overriding the logger:
 Rails.application.config.zen.logger = Logger.new(...)
 ```
 
-You should supply an instance of ruby's [Logger](https://github.com/ruby/logger)
+You should supply an instance of Ruby's [Logger](https://github.com/ruby/logger)
 class.

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -102,12 +102,11 @@ way.
 
 ## Logging
 
-You can redirect the log to a separate stream by overriding the logger:
+You can override the logger to integrate with your application logging strategy:
 
 ```ruby
 # config/initializers/zen.rb
-Rails.application.config.zen.logger = Logger.new(...)
+Rails.application.config.zen.logger = ::Rails.logger
 ```
 
-You should supply an instance of Ruby's [Logger](https://github.com/ruby/logger)
-class.
+Zen expects an instance of Ruby's [Logger](https://github.com/ruby/logger) class.

--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -29,12 +29,6 @@ module Aikido::Zen
     end
 
     initializer "aikido.configuration" do |app|
-      # Allow the logger to be configured before checking if disabled? so we can
-      # let the user know that the agent is disabled.
-      logger = ::Rails.logger
-      logger = logger.tagged("aikido") if logger.respond_to?(:tagged)
-      app.config.zen.logger = logger
-
       app.config.zen.request_builder = Aikido::Zen::Context::RAILS_REQUEST_BUILDER
 
       # Plug Rails' JSON encoder/decoder, but only if the user hasn't changed

--- a/sample_apps/rails7.1_path_traversal/config/initializers/zen.rb
+++ b/sample_apps/rails7.1_path_traversal/config/initializers/zen.rb
@@ -1,4 +1,6 @@
 # If you don't want to depend on ENV vars, this is another way to
 # configure the Zen library.
 if Rails.application.config.respond_to?(:zen)
+  Rails.application.config.zen.blocking_mode = true
+  Rails.application.config.zen.logger = ::Rails.logger.tagged("aikido")
 end

--- a/sample_apps/rails7.1_sql_injection/config/initializers/zen.rb
+++ b/sample_apps/rails7.1_sql_injection/config/initializers/zen.rb
@@ -2,4 +2,5 @@
 # configure the Zen library.
 if Rails.application.config.respond_to?(:zen)
   Rails.application.config.zen.blocking_mode = true
+  Rails.application.config.zen.logger = ::Rails.logger.tagged("aikido")
 end

--- a/sample_apps/rails7.1_template/config/initializers/zen.rb
+++ b/sample_apps/rails7.1_template/config/initializers/zen.rb
@@ -2,4 +2,5 @@
 # configure the Zen library.
 if Rails.application.config.respond_to?(:zen)
   Rails.application.config.zen.blocking_mode = true
+  Rails.application.config.zen.logger = ::Rails.logger.tagged("aikido")
 end


### PR DESCRIPTION
Automatically using the Rails logger can lead to errors when the `::Rails.logger` is configured to a `Logger`-like object that is incompatible with Ruby's Logger. Making logger reconfiguration explicit resolves potential issues, while providing the necessary flexibility for applications to correctly configure logging, i.e. to integrate output logged by `aikido-zen` with the application logging strategy.

This PR is being made in the context of internal discussions about whether or to what degree features like logging should be configurable, and noting that Zen Ruby must and already uses the default Logger to provide essential information to users during initialization; before the Rails source has been initialized.