### PR TITLE
Remove api_timeouts in example

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -60,7 +60,7 @@ modify in an initializer if desired:
 
 ```ruby
 # config/initializers/zen.rb
-Rails.application.config.zen.api_timeouts = 20
+Rails.application.config.zen.option = value
 ```
 
 You can access the configuration object both as `Aikido::Zen.config` or
@@ -80,7 +80,7 @@ zen:
   token: "AIKIDO_RUNTIME_..."
 ```
 
-You can just tell Zen to use it like so:
+You can tell Zen to use it like so:
 
 ```ruby
 # config/initializers/zen.rb


### PR DESCRIPTION
This change gives the general syntax for setting an option, but does not give a specific example. If an appropriate specific example can be suggested then this could be used here.

The purpose of this PR is to remove the reference to the `api_timeouts` configuration option, which is considered internal or too low-level to draw attention to.