### PR TITLE
Add fork detector middleware

### DIFF
--- a/lib/aikido/zen/middleware/fork_detector.rb
+++ b/lib/aikido/zen/middleware/fork_detector.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Aikido
+  module Zen
+    module Middleware
+      # This middleware is responsible for detecting when a process has forked
+      # (e.g., in a Puma or Unicorn worker) and resetting the state of the
+      # Aikido Zen agent. It should be inserted early in the middleware stack.
+      class ForkDetector
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          # This is the single, reliable trigger point for the fork check.
+          Aikido::Zen.check_and_handle_fork
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -10,6 +10,8 @@ module Aikido::Zen
     end
 
     initializer "aikido.add_middleware" do |app|
+      app.middleware.insert_before 0, Aikido::Zen::Middleware::ForkDetector
+
       app.middleware.use Aikido::Zen::Middleware::SetContext
       app.middleware.use Aikido::Zen::Middleware::CheckAllowedAddresses
       # Request Tracker stats do not consider failed request or 40x, so the middleware


### PR DESCRIPTION
This change adds middleware that calls `Aikido::Zen.check_and_handle_fork` at the start of a request, ensuring that worker processes detect and handle forking before handling the request.

The current trigger feigns to check whether the process has forked when the collector or detached agent are accessed, through `Aikido::Zen`, however, these accesses only occurs during initialization, in the parent process; child processes inherit the state of their parent, which includes initialized objects. No further accesses to the collector or detached agent, through  `Aikido::Zen`, are performed, preventing fork detection.