### PR TITLE
Fix calculate_rate_limits with nil agent_data

### DIFF
--- a/lib/aikido/zen/detached_agent/front_object.rb
+++ b/lib/aikido/zen/detached_agent/front_object.rb
@@ -33,7 +33,7 @@ module Aikido::Zen::DetachedAgent
     end
 
     def calculate_rate_limits(route_data, ip, actor_data)
-      actor = Aikido::Zen::Actor.from_json(actor_data)
+      actor = Aikido::Zen::Actor.from_json(actor_data) if actor_data
       route = Aikido::Zen::Route.from_json(route_data)
       @rate_limiter.calculate_rate_limits(RequestKind.new(route, nil, ip, actor))
     end


### PR DESCRIPTION
When no user is set, `request.agent.to_json` will return `nil`, causing `agent_data` to be `nil`. This causes an exception to be raised when trying to instantiate an `Aikido::Zen::Agent.from_json`, as should be expected.

This change conditionally creates an `Aikido::Zen::Agent.from_json` if `agent_data` is not `nil`. If this condition fails then the local variable agent returns `nil`, and the rate limiter will `calculate_rate_limits` for the route without considering the user.