### PR TITLE
Conditionally start agents

### DIFF
--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -220,11 +220,20 @@ module Aikido
       LOCK = Mutex.new
 
       def start!
+        return unless start?
+
         @pid = Process.pid
+
         LOCK.synchronize do
           agent
           detached_agent_server
         end
+      end
+
+      def start?
+        !config.api_token.nil? ||
+          config.blocking_mode? ||
+          config.debugging?
       end
 
       def check_and_handle_fork


### PR DESCRIPTION
This change conditionally starts the agents -- the Aikido agent and detached agent  -- using the same logic previously used to determine whether the sources and sinks should be loaded (and, by extension, whether the agents should be started).

The agents will be started start if, _after the application has initialized_, one or more of the following conditions are satisfied:

- The `api_token` configuration option is set in Ruby, or using the `AIKIDO_TOKEN` environment variable
- The `blocking_mode` configuration option is set to true in Ruby, or using the `AIKIDO_BLOCK` environment variable
- The `debugging` configuration option is set to true in Ruby, or using the `AIKIDO_DEBUG` environment variable

The sources and sinks are loaded when `Aikido::Zen.protect!` is called unless the `disabled` configuration option is set to true in Ruby, or using the `AIKIDO_DISABLED` environment variable.

This change helps to control the contexts in which the agents start without requiring protection to be manually disabled.

Unlike the previous implementation, this solution allows all configuration options to be set in Ruby i.e. in a Rails initializer, because these configuration options are considered after the sources and sinks have been loaded and after initialization.

See PR #173 for a discussion of the problems with the previous implementation and why it was reverted.