### PR TITLE
Fix report SQL injection attacks

### DIFF
--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -137,7 +137,7 @@ module Aikido::Zen
       def metadata
         {
           sql: @query,
-          dialect: @dialect
+          dialect: @dialect.name
         }
       end
 

--- a/test/aikido/zen/attack_test.rb
+++ b/test/aikido/zen/attack_test.rb
@@ -60,7 +60,7 @@ module Aikido::Zen
         payload: @input.value,
         metadata: {
           sql: @query,
-          dialect: @dialect
+          dialect: @dialect.name
         },
         source: "routeParams",
         path: "id"
@@ -83,7 +83,7 @@ module Aikido::Zen
         payload: @input.value,
         metadata: {
           sql: @query,
-          dialect: @dialect
+          dialect: @dialect.name
         },
         source: "routeParams",
         path: "id"


### PR DESCRIPTION
The Aikido `POST /api/runtime/events` endpoint requires all metadata values to be strings.

This change reports the dialect name value in the metadata for `Aikido::Zen::Attacks::SQLInjectionAttack` instances, instead of the `Aikido::Zen::Scanners::SQLInjectionScanner::Dialect` struct JSON object.