### PR TITLE
Add clean stack trace to attacks

### DIFF
--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -250,5 +250,24 @@ module Aikido
         @detached_agent&.handle_fork
       end
     end
+
+    # @!visibility private
+    # Returns the stack trace trimmed to where execution last entered Zen.
+    #
+    # @return [String]
+    def self.clean_stack_trace
+      stack_trace = caller_locations
+
+      spec = Gem.loaded_specs["aikido-zen"]
+
+      # Only trim stack frames from .../lib/aikido/zen/ in the aikido-zen gem,
+      # so calls in sample apps are preserved.
+      lib_path_start = File.expand_path(File.join(spec.full_gem_path, "lib", "aikido", "zen")) + File::SEPARATOR
+
+      index = stack_trace.index { |frame| !File.expand_path(frame.path).start_with?(lib_path_start) }
+      stack_trace = stack_trace[index..] if index
+
+      stack_trace.map(&:to_s).join("\n")
+    end
   end
 end

--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -10,10 +10,11 @@ module Aikido::Zen
     attr_reader :operation
     attr_accessor :sink
 
-    def initialize(context:, sink:, operation:)
+    def initialize(context:, sink:, operation:, stack: nil)
       @context = context
       @operation = operation
       @sink = sink
+      @stack = stack
       @blocked = false
     end
 
@@ -46,8 +47,9 @@ module Aikido::Zen
         kind: kind,
         blocked: blocked?,
         metadata: metadata,
-        operation: @operation
-      }.merge(input.as_json)
+        operation: @operation,
+        stack: @stack
+      }.compact.merge(input.as_json)
     end
 
     def exception(*)

--- a/lib/aikido/zen/scanners/path_traversal_scanner.rb
+++ b/lib/aikido/zen/scanners/path_traversal_scanner.rb
@@ -28,7 +28,8 @@ module Aikido::Zen
             input: payload,
             filepath: filepath,
             context: context,
-            operation: "#{sink.operation}.#{operation}"
+            operation: "#{sink.operation}.#{operation}",
+            stack: Aikido::Zen.clean_stack_trace
           )
         end
 

--- a/lib/aikido/zen/scanners/shell_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/shell_injection_scanner.rb
@@ -23,7 +23,8 @@ module Aikido::Zen
             input: payload,
             command: command,
             context: context,
-            operation: "#{sink.operation}.#{operation}"
+            operation: "#{sink.operation}.#{operation}",
+            stack: Aikido::Zen.clean_stack_trace
           )
         end
 

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -40,7 +40,8 @@ module Aikido::Zen
             input: payload,
             dialect: dialect,
             context: context,
-            operation: "#{sink.operation}.#{operation}"
+            operation: "#{sink.operation}.#{operation}",
+            stack: Aikido::Zen.clean_stack_trace
           )
         end
 

--- a/lib/aikido/zen/scanners/ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/ssrf_scanner.rb
@@ -51,7 +51,8 @@ module Aikido::Zen
             request: request,
             input: payload,
             context: context,
-            operation: "#{sink.operation}.#{operation}"
+            operation: "#{sink.operation}.#{operation}",
+            stack: Aikido::Zen.clean_stack_trace
           )
 
           return attack

--- a/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
@@ -20,7 +20,8 @@ module Aikido::Zen
           address: offending_address,
           sink: sink,
           context: context,
-          operation: "#{sink.operation}.#{operation}"
+          operation: "#{sink.operation}.#{operation}",
+          stack: Aikido::Zen.clean_stack_trace
         )
       end
 


### PR DESCRIPTION
This change supports the generation of clean stack traces. Stack traces are added to attacks, and reported to Aikido Core.

Stack traces are cleaned by trimming them at the point where execution last enters a file under the `lib/aikido/zen/` directory in the `aikido-zen` gem. This ensures that calls in i.e. sample apps (also located in the gem) are not trimmed.

Frames are only removed from the top of the stack so that stack traces remain accurate and usable (without any gaps) when execution passes through `aikido-zen` and continues in third-party or application code.