### PR TITLE
Fix prefix route path on Windows

### DIFF
--- a/lib/aikido/zen/request/rails_router.rb
+++ b/lib/aikido/zen/request/rails_router.rb
@@ -62,16 +62,31 @@ module Aikido::Zen
       nil
     end
 
-    private def build_route(route, request, prefix: request.script_name)
+    private
+
+    def build_route(route, request, prefix: request.script_name)
       route_wrapper = ActionDispatch::Routing::RouteWrapper.new(route)
 
       path = if prefix.present?
-        File.join(prefix.to_s, route_wrapper.path).chomp("/")
+        prefix_route_path(prefix.to_s, route_wrapper.path)
       else
         route_wrapper.path
       end
 
       Aikido::Zen::Route.new(verb: request.request_method, path: path)
+    end
+
+    def prefix_route_path(string1, string2)
+      # The strings appear to start with "/", allowing them to be concatenated
+      # directly after removing trailing "/". However, as it is not currently
+      # known whether this is guaranteed, we insert a separator when necessary.
+
+      separator = string2.start_with?("/") ? "" : "/"
+
+      string1 = string1.chomp("/")
+      string2 = string2.chomp("/")
+
+      "#{string1}#{separator}#{string2}"
     end
   end
 end


### PR DESCRIPTION
This change investigates and fixes the issue first suggested [here](https://github.com/AikidoSec/firewall-ruby/pull/88). 

`File.join` cannot be used to prefix the route path on Windows because the `File::SEPARATOR` used by `File.join` to join path components is backslash (`\`), which breaks URL-style paths.

This change joins two strings, assumed to be URL-style paths. It is recognized that these strings appear to start with a forward slash (`/`) and could be concatenated directly, without a separator, after removing trailing forward slashes (`/`), but this is not assumed. A separator is inserted when necessary.

While this method joins two strings, if it ever becomes necessary, it can be used to join an array of strings using `inject`:

```
strings.inject("") { |string1, string2| prefix_route_path(string1, string2) }
```