### PR TITLE
Fix non-string value path traversal bypass

### DIFF
--- a/lib/aikido/zen/scanners/path_traversal_scanner.rb
+++ b/lib/aikido/zen/scanners/path_traversal_scanner.rb
@@ -21,7 +21,7 @@ module Aikido::Zen
       # user input is detected to be attempting a Path Traversal Attack, or +nil+ if not.
       def self.call(filepath:, sink:, context:, operation:)
         context.payloads.each do |payload|
-          next unless new(filepath, payload.value).attack?
+          next unless new(filepath, payload.value.to_s).attack?
 
           return Attacks::PathTraversalAttack.new(
             sink: sink,

--- a/test/aikido/zen/scanners/path_traversal_scanner_test.rb
+++ b/test/aikido/zen/scanners/path_traversal_scanner_test.rb
@@ -98,4 +98,51 @@ class Aikido::Zen::Scanners::PathTraversalScannerTest < ActiveSupport::TestCase
     assert_attack "/var/a/b", "/var/a"
     assert_attack "/var/a/b/test.txt", "/var/a"
   end
+
+  class RailsRequestTest < ActiveSupport::TestCase
+    setup do
+      Aikido::Zen.config.request_builder = Aikido::Zen::Context::RAILS_REQUEST_BUILDER
+    end
+
+    def env_for(path, env = {})
+      env = Rack::MockRequest.env_for(path, env)
+      Rails.application.env_config.merge(env)
+    end
+
+    def build_context_for(path, env = {})
+      env = env_for(path, env)
+      Aikido::Zen::Context.from_rack_env(env)
+    end
+
+    def stub_sink(name:)
+      Aikido::Zen::Sink.new(name, operation: "test", scanners: [NOOP])
+    end
+
+    def stub_payload(source, value, path)
+      Aikido::Zen::Payload.new(value, source, path)
+    end
+
+    test ".call detects attack when non-string value precedes malicious value in context" do
+      context = build_context_for("/users", {
+        :method => "POST",
+        :input => %({
+          "a": true,
+          "user": "user/../../../etc/passwd"
+        }),
+        "CONTENT_TYPE" => "application/json"
+      })
+
+      attack = Aikido::Zen::Scanners::PathTraversalScanner.call(
+        filepath: "/app/users/user/../../../etc/passwd",
+        sink: stub_sink(name: "test"),
+        context: context,
+        operation: "test"
+      )
+
+      assert_kind_of Aikido::Zen::Attacks::PathTraversalAttack, attack
+
+      assert_equal stub_payload(:body, "user/../../../etc/passwd", "user"), attack.input
+      assert_equal "/app/users/user/../../../etc/passwd", attack.filepath
+    end
+  end
 end


### PR DESCRIPTION
The `Aikido::Zen::Scanners::PathTraversalScanner` assumes that the `payload.value` is a `String`; initially `downcase`ing it, then checking it's `length`, etc. When a `payload.value` is not a string, an error is raised that prevents the scanner from scanning later payload values, which could trigger an `Aikido::Zen::Attacks::PathTraversalAttack`.

This change converts the `payload.value` to a string prior to scanning.