### PR TITLE
Fix non-string value shell injection bypass

### DIFF
--- a/lib/aikido/zen/scanners/shell_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/shell_injection_scanner.rb
@@ -16,7 +16,7 @@ module Aikido::Zen
       #
       def self.call(command:, sink:, context:, operation:)
         context.payloads.each do |payload|
-          next unless new(command, payload.value).attack?
+          next unless new(command, payload.value.to_s).attack?
 
           return Attacks::ShellInjectionAttack.new(
             sink: sink,


### PR DESCRIPTION
The `Aikido::Zen::Scanners::ShellInjectionScanner` assumes that the `payload.value` is a `String`; initially comparing it to `"~"`, then checking it's `size`, etc. When a `payload.value` is not a string, an error is raised that prevents the scanner from scanning later payload values, which could trigger an `Aikido::Zen::Attacks::ShellInjectionAttack`.

This change converts the `payload.value` to a string prior to scanning.
