### PR TITLE
Support wildcard endpoint matching

### DIFF
--- a/lib/aikido/zen/route.rb
+++ b/lib/aikido/zen/route.rb
@@ -39,6 +39,35 @@ module Aikido::Zen
       [verb, path].hash
     end
 
+    # Sort routes by wildcard matching order deterministically:
+    #
+    #   1. Exact path before wildcard path
+    #   2. Fewer wildcards in path relative to path length
+    #   3. Earliest wildcard position in path
+    #   4. Exact verb before wildcard verb
+    #   5. Lexicographic path (tie-break)
+    #   6. Lexicographic verb (tie-break)
+    #
+    # @return [Array] the sort key
+    def sort_key
+      @sort_key ||= begin
+        stars = []
+        i = -1
+        while (i = path.index("*", i + 1))
+          stars << i
+        end
+
+        [
+          stars.empty? ? 0 : 1,
+          stars.length - path.length,
+          stars,
+          (verb == "*") ? 1 : 0,
+          path,
+          verb
+        ].freeze
+      end
+    end
+
     def match?(other)
       other.is_a?(Route) &&
         pattern(verb).match?(other.verb) &&

--- a/lib/aikido/zen/runtime_settings/endpoints.rb
+++ b/lib/aikido/zen/runtime_settings/endpoints.rb
@@ -16,15 +16,22 @@ module Aikido::Zen
     # @param data [Array<Hash>]
     # @return [Aikido::Zen::RuntimeSettings::Endpoints]
     def self.from_json(data)
-      endpoints = Array(data).map do |item|
-        route = Route.new(verb: item["method"], path: item["route"])
-        settings = RuntimeSettings::ProtectionSettings.from_json(item)
+      endpoint_pairs = Array(data).map do |value|
+        route = Route.new(verb: value["method"], path: value["route"])
+        settings = RuntimeSettings::ProtectionSettings.from_json(value)
         [route, settings]
-      end.to_h
+      end
 
-      new(endpoints)
+      # Sort endpoints by wildcard matching order
+      endpoint_pairs.sort_by! do |route, settings|
+        route.sort_key
+      end
+
+      new(endpoint_pairs.to_h)
     end
 
+    # @param endpoints [Hash] the endpoints in wildcard matching order
+    # @return [Aikido::Zen::RuntimeSettings::Endpoints]
     def initialize(endpoints = {})
       @endpoints = endpoints
       @endpoints.default = RuntimeSettings::ProtectionSettings.none

--- a/test/aikido/zen/route_test.rb
+++ b/test/aikido/zen/route_test.rb
@@ -24,6 +24,50 @@ class Aikido::Zen::RouteTest < ActiveSupport::TestCase
     assert_equal 2, counter[r2]
   end
 
+  test "routes can be sorted by sort key" do
+    routes = []
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_1")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_2")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_3")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_A")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_B")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_C")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_a")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_b")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login_c")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login1")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login2")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login3")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/loginA")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/loginB")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/loginC")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/logina")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/loginb")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/loginc")
+    routes << Aikido::Zen::Route.new(verb: "DELETE", path: "/api/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "PATCH", path: "/api/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "POST", path: "/api/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "PUT", path: "/api/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/api/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/*/*/*/login_specific_method")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/*/*/*/login_specific_method")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/*/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/*/auth/login")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/api/auth/*")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/api/auth/*")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/*/auth/*")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/*/auth/*")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "/*")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "/*")
+    routes << Aikido::Zen::Route.new(verb: "GET", path: "*")
+    routes << Aikido::Zen::Route.new(verb: "*", path: "*")
+
+    assert_equal routes, routes.shuffle.sort_by(&:sort_key)
+  end
+
   test "#as_json includes method and path" do
     route = Aikido::Zen::Route.new(verb: "GET", path: "/users/:id")
     assert_equal({method: "GET", path: "/users/:id"}, route.as_json)


### PR DESCRIPTION
This change adds support for wildcard endpoint matching against a route's verb and path, using the `*` wildcard operator.

When the endpoint settings are looked up for a route, the endpoints-with-settings are first searched by exact match against a route's verb and path, then by wildcard match. The verb and path that are matched against come from the route handling the request -- not from the request itself or the URL.

As currently implemented, wildcard matching is performed by constructing an equivalent and safe regular expression. The resulting regular expression matches the entire input, allows an optional trailing forward slash, and is case-insensitive.