### PR TITLE
Fix SSRF attack metadata port type to string

### DIFF
--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -173,7 +173,7 @@ module Aikido::Zen
       def metadata
         {
           hostname: @request.uri.hostname,
-          port: @request.uri.port
+          port: @request.uri.port.to_s
         }
       end
     end

--- a/test/aikido/zen/attack_test.rb
+++ b/test/aikido/zen/attack_test.rb
@@ -92,4 +92,142 @@ module Aikido::Zen
       assert_equal expected, attack.as_json
     end
   end
+
+  class SSRFAttackTest < ActiveSupport::TestCase
+    setup do
+      @request_uri = URI("http://localhost:7000/api/users")
+      @request = Aikido::Zen::Scanners::SSRFScanner::Request.new(
+        verb: "GET",
+        uri: @request_uri,
+        headers: {}
+      )
+      @input = Aikido::Zen::Payload.new("localhost:7000", :body, "url")
+      @context = Aikido::Zen::Context.from_rack_env({})
+      @op = "net-http.request"
+      @sink = Sink.new("net-http", scanners: [NOOP])
+    end
+
+    test "keeps track of the request and triggering input" do
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: @request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      assert_equal @request, attack.request
+      assert_equal @input, attack.input
+      assert_equal @sink, attack.sink
+      assert_equal @context, attack.context
+      assert_equal @op, attack.operation
+    end
+
+    test "generates the proper exception" do
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: @request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      assert_kind_of Aikido::Zen::SSRFDetectedError, attack.exception
+    end
+
+    test "can track if the Agent will block it" do
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: @request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      refute attack.blocked?
+
+      attack.will_be_blocked!
+      assert attack.blocked?
+    end
+
+    test "#metadata includes hostname and port as strings" do
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: @request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      metadata = attack.metadata
+
+      assert_equal "localhost", metadata[:hostname]
+      assert_equal "7000", metadata[:port]
+      assert_kind_of String, metadata[:port], "Port should be a string, not an integer"
+    end
+
+    test "#as_json includes the expected fields with port as string" do
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: @request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      expected = {
+        kind: "ssrf",
+        operation: @op,
+        blocked: false,
+        payload: @input.value,
+        metadata: {
+          hostname: "localhost",
+          port: "7000"
+        },
+        source: "body",
+        path: "url"
+      }
+
+      assert_equal expected, attack.as_json
+    end
+
+    test "#as_json reflects if the attack was blocked" do
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: @request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      attack.will_be_blocked!
+
+      expected = {
+        kind: "ssrf",
+        operation: @op,
+        blocked: true,
+        payload: @input.value,
+        metadata: {
+          hostname: "localhost",
+          port: "7000"
+        },
+        source: "body",
+        path: "url"
+      }
+
+      assert_equal expected, attack.as_json
+    end
+
+    test "#metadata handles default HTTP port 80" do
+      http_uri = URI("http://example.com/path")
+      request = Aikido::Zen::Scanners::SSRFScanner::Request.new(
+        verb: "GET",
+        uri: http_uri,
+        headers: {}
+      )
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      metadata = attack.metadata
+
+      assert_equal "example.com", metadata[:hostname]
+      assert_equal "80", metadata[:port]
+      assert_kind_of String, metadata[:port]
+    end
+
+    test "#metadata handles default HTTPS port 443" do
+      https_uri = URI("https://example.com/path")
+      request = Aikido::Zen::Scanners::SSRFScanner::Request.new(
+        verb: "GET",
+        uri: https_uri,
+        headers: {}
+      )
+      attack = Aikido::Zen::Attacks::SSRFAttack.new(
+        request: request, input: @input, sink: @sink, context: @context, operation: @op
+      )
+
+      metadata = attack.metadata
+
+      assert_equal "example.com", metadata[:hostname]
+      assert_equal "443", metadata[:port]
+      assert_kind_of String, metadata[:port]
+    end
+  end
 end


### PR DESCRIPTION
The Core API was rejecting SSRF attack events with `"400 All values should be strings" `because the `port` field in `SSRFAttack#metadata` was being sent as an integer instead of a string

`ruby-backend  | E, [2025-11-19T08:12:36.072452 #1] ERROR -- aikido: Error in POST /api/runtime/events: 400 All values should be strings ({"status_code":400,"reason_phrase":"All values should be strings"}) `