### PR TITLE
Align StoredSSRFAttack metadata field with Node implementation

### DIFF
--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -209,7 +209,7 @@ module Aikido::Zen
       def metadata
         {
           hostname: @hostname,
-          resolvedIP: @address
+          privateIP: @address
         }
       end
     end


### PR DESCRIPTION
Change `resolvedIP` to `privateIP` in `StoredSSRFAttack` metadata to match the node firewall implementation.