### PR TITLE
Add tests for allowed IPv6 addresses

### DIFF
--- a/test/aikido/zen/runtime_settings_test.rb
+++ b/test/aikido/zen/runtime_settings_test.rb
@@ -93,6 +93,27 @@ class Aikido::Zen::RuntimeSettingsTest < ActiveSupport::TestCase
     refute_includes @settings.skip_protection_for_ips, "10.0.0.2"
   end
 
+  test "#skip_protection_for_ips lets you use individual IPv6 addresses" do
+    assert @settings.update_from_json({
+      "allowedIPAddresses" => ["2001:db8::1", "2001:db8::2"]
+    })
+
+    assert_includes @settings.skip_protection_for_ips, "2001:db8::1"
+    assert_includes @settings.skip_protection_for_ips, "2001:db8::2"
+    refute_includes @settings.skip_protection_for_ips, "2001:db8::3"
+  end
+
+  test "#skip_protection_for_ips lets you pass IPv6 CIDR blocks" do
+    assert @settings.update_from_json({
+      "allowedIPAddresses" => ["2001:db8::/127", "2001:db8::100"]
+    })
+
+    assert_includes @settings.skip_protection_for_ips, "2001:db8::"
+    assert_includes @settings.skip_protection_for_ips, "2001:db8::1"
+    assert_includes @settings.skip_protection_for_ips, "2001:db8::100"
+    refute_includes @settings.skip_protection_for_ips, "2001:db8::2"
+  end
+
   test "parsing endpoint data" do
     assert @settings.update_from_json({
       "success" => true,


### PR DESCRIPTION
This change expands the tests for the `allowed_ip` runtime setting, covering cases where the allowed IP is an individual IPv6 address or IPv6 CIDR range.