### PR TITLE
Close socket when scan raises an escaping exception

### DIFF
--- a/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
@@ -45,6 +45,9 @@ module Aikido::Zen
 
       DANGEROUS_ADDRESSES = [
         IPAddr.new("169.254.169.254"),
+        IPAddr.new("100.100.100.200"),
+        IPAddr.new("::ffff:169.254.169.254"),
+        IPAddr.new("::ffff:100.100.100.200"),
         IPAddr.new("fd00:ec2::254")
       ]
     end

--- a/lib/aikido/zen/sinks/socket.rb
+++ b/lib/aikido/zen/sinks/socket.rb
@@ -68,6 +68,13 @@ module Aikido::Zen
             # :nocov:
             Helpers.scan(remote_host, socket, "open")
             # :nocov:
+          rescue Aikido::Zen::UnderAttackError, Aikido::Zen::Sinks::DSL::PresafeError
+            # If the scan raises an exception that will escape the safe block,
+            # the open socket must be closed because it will not be returned,
+            # so the user cannot close it.
+            socket.close
+
+            raise
           end
         end
       end


### PR DESCRIPTION
This change immediately closes the `IPSocket` that was just opened when the scan raises an exception that will escape the `safe` block in the `sink_after` `open`:

`Aikido::Zen::UnderAttackError`
`Aikido::Zen::Sinks::DSL::PresafeError`

This is necessary because, when scan raises an exception that will abort handling the request, the socket is not returned and the application is unable to close it.

This prevents the connection from remaining open for the indefinite period until the garbage collector deems to finalize it; releasing the resource immediately.