### PR TITLE
Fix the Smoke Test for FFI GitHub workflow

### DIFF
--- a/.github/workflows/smoke_test_ffi.yml
+++ b/.github/workflows/smoke_test_ffi.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up the correct Gemfile for Ruby ${{ matrix.ruby }}
         run: bin/link_gemfile "${{ matrix.ruby }}"
-      # Lock files are generated for a specific platform
-      - run: rm Gemfile.lock
       - name: Install system dependencies
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
The Smoke Test for FFI GitHub workflow started failing yesterday. The issue has been traced to the release of Minitest 6.0. The Gemfiles do not specify a version constraint for `minitest`, and `smoke_test_ffi.yml` removes the `Gemfile.lock` file.

This change preserves `Gemfile.lock`, ensuring that the Gem versions specified in `Gemfile.lock` are used when running the Smoke Test for FFI GitHub workflow (as in the other workflows).

The `ruby/setup-ruby` third-party GitHub Action is now pinned, to prevent future issues. This change is preventative and is not related to this issue.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
**⚡ Enhancements**
* Pinned ruby/setup-ruby action to a specific commit

**🐛 Bugfixes**
* Preserved Gemfile.lock to prevent unintended gem upgrades
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->