### PR TITLE
Clarify configuration option documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -5,22 +5,6 @@ changing values on the `Aikido::Zen.config` object, which you can do from
 your app's startup file (like an initializer in Rails, or `config.ru` in
 other Rack-based apps).
 
-## Middleware insertion
-
-By default, the Zen middleware is inserted after `ActionDispatch::Executor`.
-You can change this by setting `Aikido::Zen.config.insert_middleware_after`
-to the desired middleware class or index.
-
-```ruby
-Aikido::Zen.config.insert_middleware_after = Rails::Rack::Logger
-```
-
-If you set it to `nil`, the Zen middleware is inserted at the very beginning
-of the middleware stack.
-
-Only set this if other middleware is inserted in a way that conflicts with
-the Zen middleware; for most applications, you will not need to set this.
-
 ## Disable Zen
 
 In order to fully turn off Zen and prevent it from intercepting any requests or


### PR DESCRIPTION
The existing documentation for the `Aikido::Zen.config.harden` and `Aikido::Zen.config.insert_middleware_after` configuration options is technically complex and could benefit from clarification, particularly around when these two configurations options are or are not expected to be used.