### PR TITLE
Fix QA test test_user_rate_limiting_1_minute_enable_disable

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -70,4 +70,4 @@ jobs:
           sleep_before_test: 30
           extra_args: "-e RAILS_ENV=test -e AIKIDO_CLIENT_IP_HEADER=HTTP_X_FORWARDED_FOR"
           max_parallel_tests: 15
-          skip_tests: test_rate_limiting_group_id_1_minute,test_user_rate_limiting_1_minute_enable_disable
+          skip_tests: test_rate_limiting_group_id_1_minute

--- a/lib/aikido/zen/actor.rb
+++ b/lib/aikido/zen/actor.rb
@@ -65,7 +65,7 @@ module Aikido::Zen
     def initialize(
       id:,
       name: nil,
-      ip: Aikido::Zen.current_context&.request&.ip,
+      ip: Aikido::Zen.current_context&.request&.client_ip,
       first_seen_at: Time.now.utc,
       last_seen_at: first_seen_at
     )
@@ -96,7 +96,7 @@ module Aikido::Zen
     #   always keep the most recent time if this conflicts with the current
     #   value.
     # @return [void]
-    def update(seen_at: Time.now.utc, ip: Aikido::Zen.current_context&.request&.ip)
+    def update(seen_at: Time.now.utc, ip: Aikido::Zen.current_context&.request&.client_ip)
       @last_seen_at.try_update { |last_seen_at| [last_seen_at, seen_at].max }
       @ip.try_update { |last_ip| [ip, last_ip].compact.first }
     end

--- a/lib/aikido/zen/rate_limiter.rb
+++ b/lib/aikido/zen/rate_limiter.rb
@@ -16,12 +16,7 @@ module Aikido::Zen
     )
       @config = config
       @settings = settings
-      @buckets = Hash.new { |store, route|
-        synchronize {
-          settings = settings_for(route)
-          store[route] = Bucket.new(ttl: settings.period, max_size: settings.max_requests)
-        }
-      }
+      @buckets = {}
     end
 
     # Calculate based on the configuration whether a request will be
@@ -30,24 +25,30 @@ module Aikido::Zen
     # @param request [Aikido::Zen::Request]
     # @return [Aikido::Zen::RateLimiter::Result, nil]
     def calculate_rate_limits(request)
-      route, enabled = resolve_route_enabled(request)
-      return nil unless enabled
+      route, settings = @settings.endpoints.match(request.route)
 
-      bucket = @buckets[route]
+      rate_limit_settings = settings&.rate_limiting
+
+      return nil unless rate_limit_settings&.enabled?
+
+      bucket = nil
+
+      synchronize do
+        bucket = @buckets[route]
+
+        if bucket.nil? || bucket.settings_changed?(rate_limit_settings)
+          bucket = Bucket.new(
+            ttl: rate_limit_settings.period,
+            max_size: rate_limit_settings.max_requests,
+            settings: rate_limit_settings
+          )
+
+          @buckets[route] = bucket
+        end
+      end
+
       key = @config.rate_limiting_discriminator.call(request)
       bucket.increment(key)
-    end
-
-    private
-
-    def resolve_route_enabled(request)
-      @settings.endpoints.match(request.route) do |route, settings|
-        [route, settings.rate_limiting.enabled?]
-      end
-    end
-
-    def settings_for(route)
-      @settings.endpoints[route].rate_limiting
     end
   end
 end

--- a/lib/aikido/zen/rate_limiter/bucket.rb
+++ b/lib/aikido/zen/rate_limiter/bucket.rb
@@ -29,14 +29,21 @@ module Aikido::Zen
     # @!visibility private
     #
     # Use the monotonic clock to ensure time differences are consistent
-    # and not affected by timezones.or daylight savings changes.
+    # and not affected by timezones or daylight savings changes.
     DEFAULT_CLOCK = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC).round }
 
-    def initialize(ttl:, max_size:, clock: DEFAULT_CLOCK)
+    # @param ttl [Integer] the time to live in seconds
+    # @param max_size [Integer] the number of requests before throttling
+    # @param clock [#call() => Integer] a callable that returns the current
+    #   monotonic time in seconds
+    # @param settings [Aikido::Zen::RuntimeSettings::RateLimitSettings, nil]
+    #   the settings that might change
+    def initialize(ttl:, max_size:, clock: DEFAULT_CLOCK, settings: nil)
       @ttl = ttl
       @max_size = max_size
       @data = Hash.new { |h, k| h[k] = [] }
       @clock = clock
+      @settings = settings
     end
 
     # Increments the key if the number of entries within the current TTL window
@@ -67,10 +74,21 @@ module Aikido::Zen
       end
     end
 
+    # Checks whether the settings provided at initialization have changed.
+    #
+    # @param settings [Aikido::Zen::RuntimeSettings::RateLimitSettings]
+    # @return [Boolean] true if settings were provided at initialization and
+    #   the settings have changed
+    def settings_changed?(settings)
+      !@settings.nil? && @settings != settings
+    end
+
     private
 
     def evict(key, at: @clock.call)
-      synchronize { @data[key].delete_if { |time| time < (at - @ttl) } }
+      synchronize do
+        @data[key].delete_if { |time| time < (at - @ttl) }
+      end
     end
   end
 end

--- a/lib/aikido/zen/runtime_settings/rate_limit_settings.rb
+++ b/lib/aikido/zen/runtime_settings/rate_limit_settings.rb
@@ -28,6 +28,9 @@ module Aikido::Zen
       new(enabled: false)
     end
 
+    # @return [Boolean]
+    attr_reader :enabled
+
     # @return [Integer] the fixed window to bucket requests in, in seconds.
     attr_reader :period
 
@@ -43,5 +46,13 @@ module Aikido::Zen
     def enabled?
       @enabled
     end
+
+    def ==(other)
+      other.is_a?(self.class) &&
+        other.enabled == enabled &&
+        other.period == period &&
+        other.max_requests == max_requests
+    end
+    alias_method :eql?, :==
   end
 end

--- a/test/aikido/zen/rate_limiter_test.rb
+++ b/test/aikido/zen/rate_limiter_test.rb
@@ -185,13 +185,13 @@ class Aikido::Zen::RateLimiterTest < ActiveSupport::TestCase
     configure "GET", "/ba*", max_requests: 3, period: 1
 
     refute_throttled build_request("GET", "/bar", ip: "1.2.3.4"), current: 1
-    refute_throttled build_request("GET", "/bar", ip: "1.2.3.4"), current: 2
+    refute_throttled build_request("GET", "/baz", ip: "1.2.3.4"), current: 2
     refute_throttled build_request("GET", "/bar", ip: "1.2.3.4"), current: 3
-    assert_throttled build_request("GET", "/bar", ip: "1.2.3.4"), current: 3
+    assert_throttled build_request("GET", "/baz", ip: "1.2.3.4"), current: 3
 
+    assert_throttled build_request("GET", "/bar", ip: "1.2.3.4"), current: 3
     assert_throttled build_request("GET", "/baz", ip: "1.2.3.4"), current: 3
-    assert_throttled build_request("GET", "/baz", ip: "1.2.3.4"), current: 3
-    assert_throttled build_request("GET", "/baz", ip: "1.2.3.4"), current: 3
+    assert_throttled build_request("GET", "/bar", ip: "1.2.3.4"), current: 3
 
     refute_throttled build_request("GET", "/foo", ip: "1.2.3.4"), current: 1
     refute_throttled build_request("GET", "/foo", ip: "1.2.3.4"), current: 2


### PR DESCRIPTION
This change fixes the QA test test_user_rate_limiting_1_minute_enable_disable by discarding the `Aikido::Zen::RateLimiter:: Bucket` in `Aikido::Zen::RateLimiter` to reset counters when any of the `Aikido::Zen::RuntimeSettings::RateLimitSettings` properties are modified.

`Aikido::Zen::Actor` now uses `Aikido::Zen::Request#client_ip` to correctly get the users IP. This improvement is related to this change but does not contribute directly to the eventual fix.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Actor now used request.client_ip to obtain user IP correctly
* Runtime rate limit settings exposed equality and enabled reader methods
* Re-enabled QA test in workflow by removing it from skip list

**🐛 Bugfixes**
* Reset rate limiting buckets when settings changed to reset counters

**🔧 Refactors**
* Reworked RateLimiter bucket initialization and synchronization logic for clarity


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91812644?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->