### PR TITLE
Fix Regexp::TimeoutError SQL injection bypass

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,7 +3,7 @@
 # Due to dependency resolution, on Ruby 2.x we're stuck with a _very_ old
 # SimpleCov version, and it doesn't really give us any benefit to run coverage
 # in separate ruby versions since we don't branch on ruby version in the code.
-return if RUBY_VERSION < "3.0"
+return if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
 return if ENV["DISABLE_COVERAGE"] == "true"
 
 # Output coverage as LCOV to support CodeCov

--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 
 require "bundler/setup"
 require "aikido/zen"
-require "debug" if RUBY_VERSION >= "3.0"
+require "debug" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -188,6 +188,11 @@ module Aikido::Zen
     #   Defaults to 15 entries.
     attr_accessor :attack_wave_max_cache_samples
 
+    # @return [Float, nil] the timeout in seconds for regular expression matching.
+    #  Applied to selected internal regular expressions to mitigate ReDoS risks.
+    #  Defaults to 1.0 seconds.
+    attr_accessor :redos_regexp_timeout
+
     def initialize
       self.insert_middleware_after = ::ActionDispatch::RemoteIp
       self.disabled = read_boolean_from_env(ENV.fetch("AIKIDO_DISABLE", false)) || read_boolean_from_env(ENV.fetch("AIKIDO_DISABLED", false))
@@ -227,6 +232,7 @@ module Aikido::Zen
       self.attack_wave_min_time_between_events = 20 * 60 * 1000 # 20 min (ms)
       self.attack_wave_max_cache_entries = 10_000
       self.attack_wave_max_cache_samples = 15
+      self.redos_regexp_timeout = 1.0
     end
 
     # Set the base URL for API requests.

--- a/lib/aikido/zen/helpers.rb
+++ b/lib/aikido/zen/helpers.rb
@@ -19,6 +19,16 @@ module Aikido
         normalized_path.chomp!("/") unless normalized_path == "/"
         normalized_path
       end
+
+      # Returns a copy of the regexp with the timeout set if timeout is supported.
+      #
+      # @param regexp [Regexp] the regexp
+      # @return [Regexp] the regexp with timeout set
+      def self.regexp_with_timeout(regexp, timeout: Aikido::Zen.config.redos_regexp_timeout)
+        return regexp if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
+
+        Regexp.new(regexp.source, regexp.options, timeout: timeout)
+      end
     end
   end
 end

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -71,7 +71,7 @@ module Aikido::Zen
         return false if /\A[[:alnum:]_]+\z/i.match?(@input)
 
         # If the input is a comma-separated list of numbers, ignore it.
-        return false if /\A[\s,]*\d[\s,\d]*\z/.match?(@input)
+        return false if /\A[ ,]*\d[ ,\d]*\z/.match?(@input)
 
         Internals.detect_sql_injection(@query, @input, @dialect)
       rescue => err

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -74,6 +74,10 @@ module Aikido::Zen
         return false if /\A(?:\d+(?:,\s*)?)+\z/i.match?(@input)
 
         Internals.detect_sql_injection(@query, @input, @dialect)
+      rescue => err
+        return true if defined?(Regexp::TimeoutError) && err.is_a?(Regexp::TimeoutError)
+
+        raise err
       end
 
       # @api private

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -71,7 +71,7 @@ module Aikido::Zen
         return false if /\A[[:alnum:]_]+\z/i.match?(@input)
 
         # If the input is a comma-separated list of numbers, ignore it.
-        return false if /\A(?:\d+(?:,\s*)?)+\z/i.match?(@input)
+        return false if /\A[\s,]*\d[\s,\d]*\z/.match?(@input)
 
         Internals.detect_sql_injection(@query, @input, @dialect)
       rescue => err

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -68,10 +68,10 @@ module Aikido::Zen
         return false unless @query.include?(@input)
 
         # If the input is solely alphanumeric, we can ignore it
-        return false if /\A[[:alnum:]_]+\z/i.match?(@input)
+        return false if Aikido::Zen::Helpers.regexp_with_timeout(/\A[[:alnum:]_]+\z/i).match?(@input)
 
         # If the input is a comma-separated list of numbers, ignore it.
-        return false if /\A[ ,]*\d[ ,\d]*\z/.match?(@input)
+        return false if Aikido::Zen::Helpers.regexp_with_timeout(/\A[ ,]*\d[ ,\d]*\z/).match?(@input)
 
         Internals.detect_sql_injection(@query, @input, @dialect)
       rescue => err

--- a/lib/aikido/zen/sinks.rb
+++ b/lib/aikido/zen/sinks.rb
@@ -21,7 +21,7 @@ require_relative "sinks/net_http"
 
 # http.rb aims to support and is tested against Ruby 3.0+:
 # https://github.com/httprb/http?tab=readme-ov-file#supported-ruby-versions
-require_relative "sinks/http" if RUBY_VERSION >= "3.0"
+require_relative "sinks/http" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 
 require_relative "sinks/httpx"
 require_relative "sinks/httpclient"

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -37,6 +37,7 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 20, @config.api_schema_collection_max_properties
     assert_equal true, @config.stored_ssrf?
     assert_equal ["metadata.google.internal", "metadata.goog"], @config.imds_allowed_hosts
+    assert_equal 1.0, @config.redos_regexp_timeout
   end
 
   test "can set AIKIDO_DISABLE to configure if the agent should be turned off" do

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -249,6 +249,17 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     refute_attack "SELECT * FROM users_123", "users_123"
   end
 
+  test "ignores numbers" do
+    refute_attack "SELECT * WHERE id = 123", "123"
+    refute_attack "SELECT * WHERE id =   123  ", "  123  "
+  end
+
+  test "ignores comma-separated list of numbers" do
+    refute_attack "SELECT * WHERE id IN (1,2,3)", "1,2,3"
+    refute_attack "SELECT * WHERE id IN (1, 2, 3)", "1, 2, 3"
+    refute_attack "SELECT * WHERE id IN (,1,,)", ",1,,"
+  end
+
   test "ignores input that does not show up in the SQL query" do
     refute_attack "SELECT * FROM users WHERE id IN (1,2,3)", "1,2,3"
     refute_attack "SELECT * FROM users", "1,2,3"

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -276,7 +276,7 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
   end
 
   test "it flags regular expression matching timeouts as attacks" do
-    skip if RUBY_VERSION < "3.2"
+    skip_if_ruby_lower_than("3.2")
 
     begin
       timeout = Regexp.timeout

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -254,6 +254,19 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     refute_attack "SELECT * FROM users", "1,2,3"
   end
 
+  test "it flags regular expression matching timeouts as attacks" do
+    timeout = Regexp.timeout
+    Regexp.timeout = 0.01
+
+    refute_attack "SELECT * FROM users WHERE id IN (123,)", "123,"
+
+    input = "1," * 1 * 1024 * 1024
+
+    assert_attack "SELECT * FROM users WHERE id IN (#{input})", input
+  ensure
+    Regexp.timeout = timeout
+  end
+
   test "attacks are not prevented if libzen can't be loaded" do
     assert_attack "SELECT * FROM users WHERE id = '' OR true; --'", "' OR true; --'"
 

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -254,10 +254,20 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     refute_attack "SELECT * WHERE id =   123  ", "  123  "
   end
 
+  test "flags invalid whitespace around numbers" do
+    assert_attack "SELECT * WHERE id = \n123\n", "\n123\n"
+    assert_attack "SELECT * WHERE id = \t123\t", "\t123\t"
+  end
+
   test "ignores comma-separated list of numbers" do
     refute_attack "SELECT * WHERE id IN (1,2,3)", "1,2,3"
     refute_attack "SELECT * WHERE id IN (1, 2, 3)", "1, 2, 3"
     refute_attack "SELECT * WHERE id IN (,1,,)", ",1,,"
+  end
+
+  test "flags invalid whitespace in comma-separated lists of numbers" do
+    assert_attack "SELECT * WHERE id IN (1,\n2,\n3,\n)", "1,\n2,\n3,\n"
+    assert_attack "SELECT * WHERE id IN (1,\t2,\t3,\t)", "1,\t2,\t3,\t"
   end
 
   test "ignores input that does not show up in the SQL query" do

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -276,16 +276,20 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
   end
 
   test "it flags regular expression matching timeouts as attacks" do
-    timeout = Regexp.timeout
-    Regexp.timeout = 0.01
+    skip if RUBY_VERSION < "3.2"
 
-    refute_attack "SELECT * FROM users WHERE id IN (123,)", "123,"
+    begin
+      timeout = Regexp.timeout
+      Regexp.timeout = 0.01
 
-    input = "1," * 1 * 1024 * 1024
+      refute_attack "SELECT * FROM users WHERE id IN (123,)", "123,"
 
-    assert_attack "SELECT * FROM users WHERE id IN (#{input})", input
-  ensure
-    Regexp.timeout = timeout
+      input = "1," * 1 * 1024 * 1024
+
+      assert_attack "SELECT * FROM users WHERE id IN (#{input})", input
+    ensure
+      Regexp.timeout = timeout
+    end
   end
 
   test "attacks are not prevented if libzen can't be loaded" do

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -278,18 +278,13 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
   test "it flags regular expression matching timeouts as attacks" do
     skip_if_ruby_lower_than("3.2")
 
-    begin
-      timeout = Regexp.timeout
-      Regexp.timeout = 0.01
+    input = "1," * 1 * 1024 * 1024
 
-      refute_attack "SELECT * FROM users WHERE id IN (123,)", "123,"
+    refute_attack "SELECT * FROM users WHERE id IN (#{input})", input
 
-      input = "1," * 1 * 1024 * 1024
+    Aikido::Zen.config.redos_regexp_timeout = 0.001
 
-      assert_attack "SELECT * FROM users WHERE id IN (#{input})", input
-    ensure
-      Regexp.timeout = timeout
-    end
+    assert_attack "SELECT * FROM users WHERE id IN (#{input})", input
   end
 
   test "attacks are not prevented if libzen can't be loaded" do

--- a/test/aikido/zen/sinks/async_http_test.rb
+++ b/test/aikido/zen/sinks/async_http_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Async::HTTP only supports ruby 3.1+
-return if RUBY_VERSION < "3.1"
+return if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1")
 
 require "test_helper"
 require "async/http/middleware/location_redirector"

--- a/test/aikido/zen/sinks/http_test.rb
+++ b/test/aikido/zen/sinks/http_test.rb
@@ -2,7 +2,7 @@
 
 # http.rb aims to support and is tested against Ruby 3.0+:
 # https://github.com/httprb/http?tab=readme-ov-file#supported-ruby-versions
-return if RUBY_VERSION < "3.0"
+return if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
 
 require "test_helper"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@
 require "bundler"
 Bundler.setup
 
-require "simplecov-lcov" if RUBY_VERSION >= "3"
+require "simplecov-lcov" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 require "simplecov"
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
@@ -16,7 +16,7 @@ require "active_support/testing/setup_and_teardown"
 require "action_dispatch"
 require "action_dispatch/routing/inspector"
 require "pathname"
-require "debug" if RUBY_VERSION >= "3"
+require "debug" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
 require "support/capture_stream"
 
 class FakeDetachedAgent
@@ -167,7 +167,7 @@ class ActiveSupport::TestCase
   end
 
   def skip_if_ruby_lower_than(expected_ruby_version)
-    if expected_ruby_version > RUBY_VERSION
+    if Gem::Version.new(expected_ruby_version) > Gem::Version.new(RUBY_VERSION)
       skip "Skipping test #{__method__} because unexpected ruby version (#{RUBY_VERSION} < #{expected_ruby_version})"
     end
   end


### PR DESCRIPTION
Since Ruby 3.2, if `Regexp.timeout` is set, regular expression matching is aborted after `Regexp.timeout` by raising `Regexp::TimeoutError`.  Since Rails 8.0, `Regexp.timeout` is set to 1 second by default. This change treats a `Regexp::TimeoutError` during SQL injection detection as an attack.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Introduced regexp_with_timeout helper and redos_regexp_timeout configuration

**🐛 Bugfixes**
* Treated Regexp::TimeoutError during SQL detection as an attack

**🔧 Refactors**
* Replaced string RUBY_VERSION compare with Gem::Version comparison


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112373041?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->