### PR TITLE
Normalize hostname to lowercase

### DIFF
--- a/lib/aikido/zen/outbound_connection.rb
+++ b/lib/aikido/zen/outbound_connection.rb
@@ -30,7 +30,7 @@ module Aikido::Zen
     attr_reader :hits
 
     def initialize(host:, port:)
-      @host = host
+      @host = host.downcase
       @port = port
     end
 

--- a/test/aikido/zen/outbound_connection_test.rb
+++ b/test/aikido/zen/outbound_connection_test.rb
@@ -19,15 +19,27 @@ class Aikido::Zen::OutboundConnectionTest < ActiveSupport::TestCase
     assert_equal 443, https_conn.port
   end
 
-  test "two connections are equal if their host and port are equal" do
+  test "hostname is normalized to lowercase" do
     c1 = Aikido::Zen::OutboundConnection.new(host: "example.com", port: 80)
-    c2 = Aikido::Zen::OutboundConnection.new(host: "example.com", port: 80)
-    c3 = Aikido::Zen::OutboundConnection.new(host: "example.com", port: 443)
-    c4 = Aikido::Zen::OutboundConnection.new(host: "example.org", port: 80)
+    c2 = Aikido::Zen::OutboundConnection.new(host: "Example.com", port: 80)
+    c3 = Aikido::Zen::OutboundConnection.new(host: "EXAMPLE.COM", port: 80)
+
+    assert_equal "example.com", c1.host
+    assert_equal "example.com", c2.host
+    assert_equal "example.com", c3.host
+  end
+
+  test "two connections are equal if their host and port are equal independent of case" do
+    c1 = Aikido::Zen::OutboundConnection.new(host: "example.com", port: 80)
+    c2 = Aikido::Zen::OutboundConnection.new(host: "Example.com", port: 80)
+    c3 = Aikido::Zen::OutboundConnection.new(host: "EXAMPLE.COM", port: 80)
+    c4 = Aikido::Zen::OutboundConnection.new(host: "example.com", port: 443)
+    c5 = Aikido::Zen::OutboundConnection.new(host: "example.org", port: 80)
 
     assert_equal c1, c2
-    refute_equal c1, c3
+    assert_equal c1, c3
     refute_equal c1, c4
+    refute_equal c1, c5
   end
 
   test "connections can be used as hash keys" do


### PR DESCRIPTION
This change normalizes hostnames to lowercase by down-casing hosts passed to `Aikido::Zen::OutboundConnection.new`. `Aikido::Zen::OutboundConnection` represents hosts in `Aikido::Zen::Collector::Hosts` and communicated to Aikido Core.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Normalized hostnames to lowercase when creating OutboundConnection instances


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96645894?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->