### PR TITLE
Handle invalid JSON body payload sources

### DIFF
--- a/lib/aikido/zen/context/rack_request.rb
+++ b/lib/aikido/zen/context/rack_request.rb
@@ -14,12 +14,17 @@ module Aikido::Zen
     request = Aikido::Zen::Request.new(delegate, framework: "rack", router: router)
 
     Context.new(request) do |req|
+      query = req.GET rescue {}
+      body = req.POST rescue {}
+      header = req.normalized_headers rescue {}
+      cookie = req.cookies rescue {}
+
       {
-        query: req.GET,
-        body: req.POST,
+        query: query,
+        body: body,
         route: {},
-        header: req.normalized_headers,
-        cookie: req.cookies,
+        header: header,
+        cookie: cookie,
         subdomain: []
       }
     end

--- a/lib/aikido/zen/context/rack_request.rb
+++ b/lib/aikido/zen/context/rack_request.rb
@@ -14,10 +14,29 @@ module Aikido::Zen
     request = Aikido::Zen::Request.new(delegate, framework: "rack", router: router)
 
     Context.new(request) do |req|
-      query = req.GET rescue {}
-      body = req.POST rescue {}
-      header = req.normalized_headers rescue {}
-      cookie = req.cookies rescue {}
+      query = begin
+        req.GET
+      rescue
+        {}
+      end
+
+      body = begin
+        req.POST
+      rescue
+        {}
+      end
+
+      header = begin
+        req.normalized_headers
+      rescue
+        {}
+      end
+
+      cookie = begin
+        req.cookies
+      rescue
+        {}
+      end
 
       {
         query: query,

--- a/lib/aikido/zen/context/rails_request.rb
+++ b/lib/aikido/zen/context/rails_request.rb
@@ -34,19 +34,20 @@ module Aikido::Zen
     end
 
     Context.new(request) do |req|
-      body = begin
-        req.request_parameters
-      rescue ActionDispatch::Http::Parameters::ParseError
-        {}
-      end
+      query = req.query_parameters rescue {}
+      body = req.request_parameters rescue {}
+      route = req.path_parameters rescue {}
+      header = req.normalized_headers rescue {}
+      cookie = decrypt_cookies.call(req) rescue {}
+      subdomain = req.subdomains rescue []
 
       {
-        query: req.query_parameters,
+        query: query,
         body: body,
-        route: req.path_parameters,
-        header: req.normalized_headers,
-        cookie: decrypt_cookies.call(req),
-        subdomain: req.subdomains
+        route: route,
+        header: header,
+        cookie: cookie,
+        subdomain: subdomain
       }
     end
   end

--- a/lib/aikido/zen/context/rails_request.rb
+++ b/lib/aikido/zen/context/rails_request.rb
@@ -34,9 +34,15 @@ module Aikido::Zen
     end
 
     Context.new(request) do |req|
+      body = begin
+        req.request_parameters
+      rescue ActionDispatch::Http::Parameters::ParseError
+        {}
+      end
+
       {
         query: req.query_parameters,
-        body: req.request_parameters,
+        body: body,
         route: req.path_parameters,
         header: req.normalized_headers,
         cookie: decrypt_cookies.call(req),

--- a/lib/aikido/zen/context/rails_request.rb
+++ b/lib/aikido/zen/context/rails_request.rb
@@ -34,12 +34,41 @@ module Aikido::Zen
     end
 
     Context.new(request) do |req|
-      query = req.query_parameters rescue {}
-      body = req.request_parameters rescue {}
-      route = req.path_parameters rescue {}
-      header = req.normalized_headers rescue {}
-      cookie = decrypt_cookies.call(req) rescue {}
-      subdomain = req.subdomains rescue []
+      query = begin
+        req.query_parameters
+      rescue
+        {}
+      end
+
+      body = begin
+        req.request_parameters
+      rescue
+        {}
+      end
+
+      route = begin
+        req.path_parameters
+      rescue
+        {}
+      end
+
+      header = begin
+        req.normalized_headers
+      rescue
+        {}
+      end
+
+      cookie = begin
+        decrypt_cookies.call(req)
+      rescue
+        {}
+      end
+
+      subdomain = begin
+        req.subdomains
+      rescue
+        []
+      end
 
       {
         query: query,

--- a/test/aikido/zen/context_test.rb
+++ b/test/aikido/zen/context_test.rb
@@ -215,6 +215,28 @@ class Aikido::Zen::ContextTest < ActiveSupport::TestCase
       assert_includes context.payloads, stub_payload(:body, 3, "array.2")
     end
 
+    test "body payloads are not read from JSON-encoded bodies that cannot be parsed" do
+      context = build_context_for("/example", {
+        :method => "POST",
+        :input => %({"test":"value","nested":{"hash":"data"},"array":[1, 2, 3),
+        "CONTENT_TYPE" => "application/json"
+      })
+
+      payloads = nil
+
+      assert_silent do
+        # Suppress message from the ActionDispatch::Http::Parameters#log_parse_error_once private method
+        original_stderr = $stderr
+        $stderr = StringIO.new
+
+        payloads = context.payloads
+      ensure
+        $stderr = original_stderr
+      end
+
+      assert payloads.none? { |payload| payload.source == :body }
+    end
+
     test "relative path arrays in body payloads read from JSON-encoded bodies are joined for File.join" do
       context = build_context_for("/example", {
         :method => "POST",


### PR DESCRIPTION
This change handles invalid JSON body payload sources, not extracting body payload sources if the JSON-encoded body could not be parsed. This prevents an `ActionDispatch::Http::Parameters::ParseError` from being raised and propagating, causing the `Aikido::Zen::Middleware::RequestTracker` and `Aikido::Zen::Middleware::AttackWaveProtector` middleware to fail after the application has already processed the request.

The susceptibility of other payload sources has been investigated and discussed internally.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Rescued exceptions when extracting Rails request payload and metadata
* Wrapped Rack request parameter accesses with rescue to return defaults


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112407245?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->