### PR TITLE
Block SQL queries that fail tokenization

### DIFF
--- a/docs/invalid-sql-queries.md
+++ b/docs/invalid-sql-queries.md
@@ -1,0 +1,9 @@
+# Blocking invalid SQL queries
+
+Zen blocks SQL queries that it can't tokenize when they contain user input. This prevents attackers from bypassing SQL injection detection with malformed queries. For example, ClickHouse ignores invalid SQL after `;`, and SQLite runs queries before an unclosed `/*` comment.
+
+This is on by default. In blocking mode, these queries are blocked. In detection-only mode, they are reported but still executed.
+
+If you see false positives (legitimate queries being blocked), set
+`AIKIDO_BLOCK_INVALID_SQL=false` in your environment, or set
+`Aikido::Zen.config.block_invalid_sql = false`.

--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -138,9 +138,11 @@ module Aikido::Zen
       end
 
       def metadata
-        meta = {sql: @query, dialect: @dialect.name}
-        meta[:failedToTokenize] = "true" if @failed_to_tokenize
-        meta
+        {
+          sql: @query,
+          dialect: @dialect.name,
+          failedToTokenize: @failed_to_tokenize || nil
+        }.compact
       end
 
       def exception(*)

--- a/lib/aikido/zen/attack.rb
+++ b/lib/aikido/zen/attack.rb
@@ -121,11 +121,12 @@ module Aikido::Zen
       attr_reader :input
       attr_reader :dialect
 
-      def initialize(query:, input:, dialect:, **opts)
+      def initialize(query:, input:, dialect:, failed_to_tokenize:, **opts)
         super(**opts)
         @query = query
         @input = input
         @dialect = dialect
+        @failed_to_tokenize = failed_to_tokenize
       end
 
       def humanized_name
@@ -137,10 +138,9 @@ module Aikido::Zen
       end
 
       def metadata
-        {
-          sql: @query,
-          dialect: @dialect.name
-        }
+        meta = {sql: @query, dialect: @dialect.name}
+        meta[:failedToTokenize] = "true" if @failed_to_tokenize
+        meta
       end
 
       def exception(*)

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -165,6 +165,12 @@ module Aikido::Zen
     attr_accessor :harden
     alias_method :harden?, :harden
 
+    # @return [Boolean] whether Aikido Zen should block SQL queries that fail
+    #   tokenization when user input is present. Defaults to true. Can be set
+    #   through AIKIDO_BLOCK_INVALID_SQL environment variable.
+    attr_accessor :block_invalid_sql
+    alias_method :block_invalid_sql?, :block_invalid_sql
+
     # @return [Integer] how many suspicious requests are allowed before an
     #   attack wave detected event is reported.
     #   Defaults to 15 requests.
@@ -227,6 +233,7 @@ module Aikido::Zen
       self.stored_ssrf = read_boolean_from_env(ENV.fetch("AIKIDO_FEATURE_STORED_SSRF", true))
       self.imds_allowed_hosts = ["metadata.google.internal", "metadata.goog"]
       self.harden = read_boolean_from_env(ENV.fetch("AIKIDO_HARDEN", true))
+      self.block_invalid_sql = read_boolean_from_env(ENV.fetch("AIKIDO_BLOCK_INVALID_SQL", true))
       self.attack_wave_threshold = 15
       self.attack_wave_min_time_between_requests = 60 * 1000 # 1 min (ms)
       self.attack_wave_min_time_between_events = 20 * 60 * 1000 # 20 min (ms)

--- a/lib/aikido/zen/internals.rb
+++ b/lib/aikido/zen/internals.rb
@@ -99,16 +99,14 @@ module Aikido::Zen
         query_ptr.put_bytes(0, query_bytes)
         input_ptr.put_bytes(0, input_bytes)
 
-        case detect_sql_injection_native(query_ptr, query_bytes.bytesize, input_ptr, input_bytes.bytesize, dialect)
-        when 0 then false
-        when 1 then true
-        when 2
+        result = detect_sql_injection_native(query_ptr, query_bytes.bytesize, input_ptr, input_bytes.bytesize, dialect)
+
+        if result == 2
           attempt = format("%s query %p with input %p", dialect, query, input)
           raise InternalsError.new(attempt, "calling detect_sql_injection in", libzen_name)
-        when 3
-          # SQL tokenization failed - return false (no injection detected)
-          false
         end
+
+        result
       end
     end
 

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -30,10 +30,8 @@ module Aikido::Zen
         end
 
         context.payloads.each do |payload|
-          result = new(query, payload.value.to_s, dialect).detect
-
-          next if result == 0
-          next if result == 3 && !Aikido::Zen.config.block_invalid_sql?
+          scanner = new(query, payload.value.to_s, dialect)
+          next unless scanner.attack?
 
           return Attacks::SQLInjectionAttack.new(
             sink: sink,
@@ -43,7 +41,7 @@ module Aikido::Zen
             context: context,
             operation: "#{sink.operation}.#{operation}",
             stack: Aikido::Zen.clean_stack_trace,
-            failed_to_tokenize: result == 3
+            failed_to_tokenize: scanner.failed_to_tokenize
           )
         rescue Aikido::Zen::InternalsError => error
           Aikido::Zen.config.logger.warn(error.message)
@@ -55,38 +53,45 @@ module Aikido::Zen
         nil
       end
 
+      attr_reader :failed_to_tokenize
+
       def initialize(query, input, dialect)
         @query = query.downcase
         @input = input.downcase
         @dialect = dialect
       end
 
-      def should_return_early?
+      def attack?
         # Ignore single char inputs since they shouldn't be able to do much harm
-        return true if @input.length <= 1
+        return false if @input.length <= 1
 
         # If the input is longer than the query, then it is not part of it
-        return true if @input.length > @query.length
+        return false if @input.length > @query.length
 
         # If the input is not included in the query at all, then we are safe
-        return true unless @query.include?(@input)
+        return false unless @query.include?(@input)
 
         # If the input is solely alphanumeric, we can ignore it
-        return true if Aikido::Zen::Helpers.regexp_with_timeout(/\A[[:alnum:]_]+\z/i).match?(@input)
+        return false if Aikido::Zen::Helpers.regexp_with_timeout(/\A[[:alnum:]_]+\z/i).match?(@input)
 
         # If the input is a comma-separated list of numbers, ignore it.
-        return true if Aikido::Zen::Helpers.regexp_with_timeout(/\A[ ,]*\d[ ,\d]*\z/).match?(@input)
+        return false if Aikido::Zen::Helpers.regexp_with_timeout(/\A[ ,]*\d[ ,\d]*\z/).match?(@input)
 
-        false
+        result = Internals.detect_sql_injection(@query, @input, @dialect)
+
+        case result
+        when 0
+          false
+        when 1
+          true
+        when 3
+          @failed_to_tokenize = true
+          Aikido::Zen.config.block_invalid_sql?
+        end
       rescue => err
-        return false if defined?(Regexp::TimeoutError) && err.is_a?(Regexp::TimeoutError)
+        return true if defined?(Regexp::TimeoutError) && err.is_a?(Regexp::TimeoutError)
 
         raise err
-      end
-
-      def detect
-        return 0 if should_return_early?
-        Internals.detect_sql_injection(@query, @input, @dialect)
       end
 
       # @api private

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -30,7 +30,10 @@ module Aikido::Zen
         end
 
         context.payloads.each do |payload|
-          next unless new(query, payload.value.to_s, dialect).attack?
+          result = new(query, payload.value.to_s, dialect).detect
+
+          next if result == 0
+          next if result == 3 && !Aikido::Zen.config.block_invalid_sql?
 
           return Attacks::SQLInjectionAttack.new(
             sink: sink,
@@ -39,7 +42,8 @@ module Aikido::Zen
             dialect: dialect,
             context: context,
             operation: "#{sink.operation}.#{operation}",
-            stack: Aikido::Zen.clean_stack_trace
+            stack: Aikido::Zen.clean_stack_trace,
+            failed_to_tokenize: result == 3
           )
         rescue Aikido::Zen::InternalsError => error
           Aikido::Zen.config.logger.warn(error.message)
@@ -57,27 +61,32 @@ module Aikido::Zen
         @dialect = dialect
       end
 
-      def attack?
+      def should_return_early?
         # Ignore single char inputs since they shouldn't be able to do much harm
-        return false if @input.length <= 1
+        return true if @input.length <= 1
 
         # If the input is longer than the query, then it is not part of it
-        return false if @input.length > @query.length
+        return true if @input.length > @query.length
 
         # If the input is not included in the query at all, then we are safe
-        return false unless @query.include?(@input)
+        return true unless @query.include?(@input)
 
         # If the input is solely alphanumeric, we can ignore it
-        return false if Aikido::Zen::Helpers.regexp_with_timeout(/\A[[:alnum:]_]+\z/i).match?(@input)
+        return true if Aikido::Zen::Helpers.regexp_with_timeout(/\A[[:alnum:]_]+\z/i).match?(@input)
 
         # If the input is a comma-separated list of numbers, ignore it.
-        return false if Aikido::Zen::Helpers.regexp_with_timeout(/\A[ ,]*\d[ ,\d]*\z/).match?(@input)
+        return true if Aikido::Zen::Helpers.regexp_with_timeout(/\A[ ,]*\d[ ,\d]*\z/).match?(@input)
 
-        Internals.detect_sql_injection(@query, @input, @dialect)
+        false
       rescue => err
-        return true if defined?(Regexp::TimeoutError) && err.is_a?(Regexp::TimeoutError)
+        return false if defined?(Regexp::TimeoutError) && err.is_a?(Regexp::TimeoutError)
 
         raise err
+      end
+
+      def detect
+        return 0 if should_return_early?
+        Internals.detect_sql_injection(@query, @input, @dialect)
       end
 
       # @api private

--- a/test/aikido/zen/attack_test.rb
+++ b/test/aikido/zen/attack_test.rb
@@ -15,7 +15,7 @@ module Aikido::Zen
 
     test "keeps track of the query and triggering input" do
       attack = Aikido::Zen::Attacks::SQLInjectionAttack.new(
-        query: @query, input: @input, dialect: @dialect, sink: @sink, context: @context, operation: @op
+        query: @query, input: @input, dialect: @dialect, failed_to_tokenize: false, sink: @sink, context: @context, operation: @op
       )
 
       assert_equal @query, attack.query
@@ -28,7 +28,7 @@ module Aikido::Zen
 
     test "generates the proper exception" do
       attack = Aikido::Zen::Attacks::SQLInjectionAttack.new(
-        query: @query, input: @input, dialect: @dialect, sink: @sink, context: @context, operation: @op
+        query: @query, input: @input, dialect: @dialect, failed_to_tokenize: false, sink: @sink, context: @context, operation: @op
       )
 
       assert_kind_of Aikido::Zen::SQLInjectionError, attack.exception
@@ -39,7 +39,7 @@ module Aikido::Zen
 
     test "can track if the Agent will block it" do
       attack = Aikido::Zen::Attacks::SQLInjectionAttack.new(
-        query: @query, input: @input, dialect: @dialect, sink: @sink, context: @context, operation: @op
+        query: @query, input: @input, dialect: @dialect, failed_to_tokenize: false, sink: @sink, context: @context, operation: @op
       )
 
       refute attack.blocked?
@@ -50,7 +50,7 @@ module Aikido::Zen
 
     test "#as_json includes the expected fields" do
       attack = Aikido::Zen::Attacks::SQLInjectionAttack.new(
-        query: @query, input: @input, dialect: @dialect, sink: @sink, context: @context, operation: @op
+        query: @query, input: @input, dialect: @dialect, failed_to_tokenize: false, sink: @sink, context: @context, operation: @op
       )
 
       expected = {
@@ -71,7 +71,7 @@ module Aikido::Zen
 
     test "#as_json reflects if the attack was blocked" do
       attack = Aikido::Zen::Attacks::SQLInjectionAttack.new(
-        query: @query, input: @input, dialect: @dialect, sink: @sink, context: @context, operation: @op
+        query: @query, input: @input, dialect: @dialect, failed_to_tokenize: false, sink: @sink, context: @context, operation: @op
       )
 
       attack.will_be_blocked!

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -14,7 +14,7 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
 
     def scan(query, input = query, dialect = :common)
       dialect = Aikido::Zen::Scanners::SQLInjectionScanner::DIALECTS.fetch(dialect)
-      Aikido::Zen::Scanners::SQLInjectionScanner.new(query, input, dialect).attack?
+      Aikido::Zen::Scanners::SQLInjectionScanner.new(query, input, dialect).detect == 1
     end
   end
 

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -14,7 +14,7 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
 
     def scan(query, input = query, dialect = :common)
       dialect = Aikido::Zen::Scanners::SQLInjectionScanner::DIALECTS.fetch(dialect)
-      Aikido::Zen::Scanners::SQLInjectionScanner.new(query, input, dialect).detect == 1
+      Aikido::Zen::Scanners::SQLInjectionScanner.new(query, input, dialect).attack?
     end
   end
 

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -314,6 +314,18 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     end
   end
 
+  test "it blocks failed tokenization when block_invalid_sql is true" do
+    Aikido::Zen.config.block_invalid_sql = true
+
+    assert_attack "SELECT * FROM comments WHERE comment = 'I'm writting you'"
+  end
+
+  test "it allows failed tokenization when block_invalid_sql is false" do
+    Aikido::Zen.config.block_invalid_sql = false
+
+    refute_attack "SELECT * FROM comments WHERE comment = 'I'm writting you'"
+  end
+
   class TestMySQLDialect < ActiveSupport::TestCase
     include Assertions
 


### PR DESCRIPTION
Our SQL injection detection tokenizes queries to check them. If the tokenizer can't parse a query, we skip it and the query goes through. Some databases still execute partially valid queries though: ClickHouse ignores junk after ; and SQLite runs everything before an unclosed /*.

Now when user input shows up in a query we can't tokenize, we treat it as an attack. On by default, opt out with AIKIDO_BLOCK_INVALID_SQL=false or config.block_invalid_sql = false.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added config.block_invalid_sql option defaulting to block invalid SQL
* Updated SQLInjectionScanner to treat tokenization failures as attacks
* Included failedToTokenize flag in SQLInjectionAttack metadata output

**🔧 Refactors**
* Changed internals detect_sql_injection to return raw result codes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112779276?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->