### PR TITLE
Add IDOR protection

### DIFF
--- a/docs/idor-protection.md
+++ b/docs/idor-protection.md
@@ -1,0 +1,130 @@
+# IDOR Protection
+
+IDOR stands for Insecure Direct Object Reference — it's when one account can access another account's data because a query doesn't properly filter by account.
+
+If your SaaS has accounts (or organizations, workspaces, teams, ...) and uses a column like `tenant_id` to keep each account's data separate, IDOR protection ensures every SQL query filters on the correct tenant. Zen analyzes queries at runtime and raises an error if a query is missing that filter or uses the wrong tenant ID, catching mistakes like:
+
+- A `SELECT` that forgets the tenant filter, letting one account read another's orders
+- An `UPDATE` or `DELETE` without a tenant filter, letting one account modify another's data
+- An `INSERT` that omits the tenant column, creating orphaned or misassigned rows
+
+Zen catches these at runtime so they surface during development and testing, not in production. See [IDOR vulnerability explained](https://www.aikido.dev/blog/idor-vulnerability-explained) for more background.
+
+> [!IMPORTANT]
+> IDOR protection always raises an `Aikido::Zen::IDOR::Error` on violations regardless of block/detect mode. A missing filter is a developer bug, not an external attack.
+
+## Setup
+
+### 1. Enable IDOR protection at startup
+
+```ruby
+...
+
+Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+Aikido::Zen.config.idor_excluded_table_names = ["users"]
+Aikido::Zen.enable_idor_protection
+
+...
+```
+
+- `idor_tenant_column_name` — the column name that identifies the tenant in your database tables (e.g. `account_id`, `organization_id`, `team_id`).
+- `idor_excluded_table_names` — tables that Zen should skip IDOR checks for, because rows aren't scoped to a single tenant (e.g. a shared `users` table that stores users across all tenants).
+
+### 2. Set the tenant ID per request
+
+Every request must have a tenant ID when IDOR protection is enabled. Call `Aikido::Zen.set_tenant_id` early in your request handler (e.g. in middleware after authentication):
+
+```ruby
+Aikido::Zen.set_tenant_id(1)
+```
+
+> [!IMPORTANT]
+> If `Aikido::Zen.set_tenant_id` is not called for a request, Zen will raise an `Aikido::Zen::IDOR::Error` when a SQL query is executed.
+
+### 3. Bypass for specific queries (optional)
+
+Some queries don't need tenant filtering (e.g. aggregations across all tenants for an admin dashboard). Use `Aikido::Zen.without_idor_protection` to bypass the check for a specific block:
+
+```ruby
+...
+
+# IDOR checks are skipped for queries inside this block
+result = Aikido::Zen.without_idor_protection do
+  db.execute("SELECT count(*) FROM agents WHERE status = 'running'");
+end
+
+...
+```
+
+## Troubleshooting
+
+<details>
+<summary>Missing tenant filter</summary>
+
+```
+Zen IDOR protection: query on table 'orders' is missing a filter on column 'tenant_id'
+```
+
+This means you have a query like `SELECT * FROM orders WHERE status = 'active'` that doesn't filter on `tenant_id`. The same check applies to `UPDATE` and `DELETE` queries.
+
+</details>
+
+<details>
+<summary>Wrong tenant ID value</summary>
+
+```
+Zen IDOR protection: query on table 'orders' filters 'tenant_id' with value '456' but tenant ID is '123'
+```
+
+This means the query filters on `tenant_id`, but the value doesn't match the tenant ID set via `Aikido::Zen.set_tenant_id`.
+
+</details>
+
+<details>
+<summary>Missing tenant column in INSERT</summary>
+
+```
+Zen IDOR protection: INSERT on table 'orders' is missing column 'tenant_id'
+```
+
+This means an `INSERT` statement doesn't include the tenant column. Every INSERT must include the tenant column with the correct tenant ID value.
+
+</details>
+
+<details>
+<summary>Wrong tenant ID in INSERT</summary>
+
+```
+Zen IDOR protection: INSERT on table 'orders' sets 'tenant_id' to '456' but tenant ID is '123'
+```
+
+This means the INSERT includes the tenant column, but the value doesn't match the tenant ID set via `Aikido::Zen.set_tenant_id`.
+
+</details>
+
+<details>
+<summary>Missing Aikido::Zen.set_tenant_id call</summary>
+
+```
+Zen IDOR protection: Aikido::Zen.set_tenant_id was not called for this request. Every request must have a tenant ID when IDOR protection is enabled.
+```
+
+</details>
+
+## Supported databases
+
+- SQLite (via `sqlite3` Gem)
+- PostgreSQL (via `pg` Gem)
+- MySQL (via `mysql2` and `trilogy` Gems)
+
+Any ORM or query builder that uses these database packages under the hood is supported (e.g. ActiveRecord). ORMs that use their own database engine are not supported unless configured to use a supported driver adapter.
+
+## Limitations
+
+## Statements that are always allowed
+
+Zen only checks statements that read or modify row data (`SELECT`, `INSERT`, `UPDATE`, `DELETE`). The following statement types are also recognized and never trigger an IDOR error:
+
+- DDL — `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, ...
+- Session commands — `SET`, `SHOW`, ...
+- Transactions — `BEGIN`, `COMMIT`, `ROLLBACK`, ...

--- a/docs/idor-protection.md
+++ b/docs/idor-protection.md
@@ -35,7 +35,6 @@ Aikido::Zen.config.idor_excluded_table_names = ["users"]
 Every request must have a tenant ID when IDOR protection is enabled. Call `Aikido::Zen.set_tenant_id` early in your request handler (e.g. in middleware after authentication):
 
 ```ruby
-Aikido::Zen.enable_idor_protection
 Aikido::Zen.set_tenant_id(1)
 ```
 

--- a/docs/idor-protection.md
+++ b/docs/idor-protection.md
@@ -20,9 +20,9 @@ Zen catches these at runtime so they surface during development and testing, not
 ```ruby
 ...
 
+Aikido::Zen.config.idor_protection_enabled = true
 Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
 Aikido::Zen.config.idor_excluded_table_names = ["users"]
-Aikido::Zen.enable_idor_protection
 
 ...
 ```
@@ -35,6 +35,7 @@ Aikido::Zen.enable_idor_protection
 Every request must have a tenant ID when IDOR protection is enabled. Call `Aikido::Zen.set_tenant_id` early in your request handler (e.g. in middleware after authentication):
 
 ```ruby
+Aikido::Zen.enable_idor_protection
 Aikido::Zen.set_tenant_id(1)
 ```
 

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -26,6 +26,8 @@ require_relative "zen/outbound_connection"
 require_relative "zen/runtime_settings"
 require_relative "zen/rate_limiter"
 require_relative "zen/attack_wave"
+require_relative "zen/sql"
+require_relative "zen/idor"
 require_relative "zen/scanners"
 
 module Aikido
@@ -213,15 +215,66 @@ module Aikido
       alias_method :set_user, :track_user
     end
 
+    # @return [Aikido::Zen::AttackWave::Detector] the attack wave detector.
+    def self.attack_wave_detector
+      @attack_wave_detector ||= AttackWave::Detector.new
+    end
+
+    # @param tenant_id [Integer, String, nil]
+    # @return [void]
+    def self.set_tenant_id(tenant_id)
+      context = current_context
+      return unless context
+
+      context.request.tenant_id = tenant_id
+    end
+
+    # @return [void]
+    def self.enable_idor_protection
+      config.idor_protection_enabled = true
+    end
+
+    # @return [void]
+    def self.disable_idor_protection
+      config.idor_protection_enabled = false
+    end
+
+    # @return [Aikido::Zen::IDOR::Protector]
+    def self.idor_protector
+      @idor_protector ||= IDOR::Protector.new
+    end
+
+    # @param sql [String]
+    # @param dialet [Symbol]
+    # @return [void]
+    # @raise [Aikido::Zen::IDOR::Error]
+    def self.idor_protect(sql, dialect_name, params = [])
+      tenant_id = current_context&.request&.tenant_id
+
+      idor_protector.protect(sql, dialect_name, params, tenant_id)
+    end
+
+    # Execute a block with the IDOR protection disabled.
+    #
+    # @yield the block to execute with the IDOR protection state set.
+    # @return [Object] the result of the block
+    # @raise [ArgumentError] if no block is given
+    def self.without_idor_protection
+      raise ArgumentError, "block required" unless block_given?
+
+      begin
+        original_idor_protection_enabled = config.idor_protection_enabled
+        config.idor_protection_enabled = false
+        yield
+      ensure
+        config.idor_protection_enabled = original_idor_protection_enabled
+      end
+    end
+
     # Marks that the Zen middleware was installed properly
     # @return void
     def self.middleware_installed!
       collector.middleware_installed!
-    end
-
-    # @return [Aikido::Zen::AttackWave::Detector] the attack wave detector.
-    def self.attack_wave_detector
-      @attack_wave_detector ||= AttackWave::Detector.new
     end
 
     # @!visibility private

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -220,6 +220,34 @@ module Aikido
       @attack_wave_detector ||= AttackWave::Detector.new
     end
 
+    # @return [Aikido::Zen::IDOR::Protector]
+    def self.idor_protector
+      @idor_protector ||= IDOR::Protector.new
+    end
+
+    # @param sql [String]
+    # @param dialect [Symbol]
+    # @return [void]
+    # @raise [Aikido::Zen::IDOR::Error]
+    def self.idor_protect(sql, dialect_name, params = [])
+      context = current_context
+      return unless context
+
+      idor_protector.protect(sql, dialect_name, params, context)
+    end
+
+    # Enable IDOR protection for the current context.
+    #
+    # @return [void]
+    def self.enable_idor_protection
+      context = current_context
+      return unless context
+
+      context.idor_protection_enabled = true
+    end
+
+    # Set the tenant ID for the current request.
+    #
     # @param tenant_id [Integer, String, nil]
     # @return [void]
     def self.set_tenant_id(tenant_id)
@@ -229,45 +257,26 @@ module Aikido
       context.request.tenant_id = tenant_id
     end
 
-    # @return [void]
-    def self.enable_idor_protection
-      config.idor_protection_enabled = true
-    end
-
-    # @return [void]
-    def self.disable_idor_protection
-      config.idor_protection_enabled = false
-    end
-
-    # @return [Aikido::Zen::IDOR::Protector]
-    def self.idor_protector
-      @idor_protector ||= IDOR::Protector.new
-    end
-
-    # @param sql [String]
-    # @param dialet [Symbol]
-    # @return [void]
-    # @raise [Aikido::Zen::IDOR::Error]
-    def self.idor_protect(sql, dialect_name, params = [])
-      tenant_id = current_context&.request&.tenant_id
-
-      idor_protector.protect(sql, dialect_name, params, tenant_id)
-    end
-
     # Execute a block with the IDOR protection disabled.
     #
-    # @yield the block to execute with the IDOR protection state set.
+    # @yield the block to execute with the IDOR protection disabled.
     # @return [Object] the result of the block
     # @raise [ArgumentError] if no block is given
     def self.without_idor_protection
       raise ArgumentError, "block required" unless block_given?
 
-      begin
-        original_idor_protection_enabled = config.idor_protection_enabled
-        config.idor_protection_enabled = false
+      context = current_context
+
+      if context
+        begin
+          original_idor_protection_enabled = context.idor_protection_enabled
+          context.idor_protection_enabled = false
+          yield
+        ensure
+          context.idor_protection_enabled = original_idor_protection_enabled
+        end
+      else
         yield
-      ensure
-        config.idor_protection_enabled = original_idor_protection_enabled
       end
     end
 

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -227,9 +227,10 @@ module Aikido
 
     # @param sql [String]
     # @param dialect [Symbol]
+    # @param params [Array, nil]
     # @return [void]
     # @raise [Aikido::Zen::IDOR::Error]
-    def self.idor_protect(sql, dialect_name, params = [])
+    def self.idor_protect(sql, dialect_name, params = nil)
       context = current_context
       return unless context
 

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -199,6 +199,23 @@ module Aikido::Zen
     #  Defaults to 1.0 seconds.
     attr_accessor :redos_regexp_timeout
 
+    # @return [Boolean] whether the IDOR protection feature is enabled.
+    #   Defaults to false.
+    attr_accessor :idor_protection_enabled
+    alias_method :idor_protection_enabled?, :idor_protection_enabled
+
+    # @return [String] the tenant column name for IDOR protection.
+    #   Defaults to nil.
+    attr_accessor :idor_tenant_column_name
+
+    # @return [Array<String>] the table names to exclude for IDOR protection.
+    #   Defaults to [].
+    attr_accessor :idor_excluded_table_names
+
+    # @return [Integer] the maximum number of entries in the LRU cache.
+    #   Defaults to 1000 entries.
+    attr_accessor :idor_max_cache_entries
+
     def initialize
       self.insert_middleware_after = ::ActionDispatch::RemoteIp
       self.disabled = read_boolean_from_env(ENV.fetch("AIKIDO_DISABLE", false)) || read_boolean_from_env(ENV.fetch("AIKIDO_DISABLED", false))
@@ -240,6 +257,10 @@ module Aikido::Zen
       self.attack_wave_max_cache_entries = 10_000
       self.attack_wave_max_cache_samples = 15
       self.redos_regexp_timeout = 1.0
+      self.idor_protection_enabled = false
+      self.idor_tenant_column_name = nil
+      self.idor_excluded_table_names = []
+      self.idor_max_cache_entries = 1000
     end
 
     # Set the base URL for API requests.

--- a/lib/aikido/zen/context.rb
+++ b/lib/aikido/zen/context.rb
@@ -30,6 +30,10 @@ module Aikido::Zen
     attr_accessor :protection_disabled
     alias_method :protection_disabled?, :protection_disabled
 
+    # @return [Boolean]
+    attr_accessor :idor_protection_enabled
+    alias_method :idor_protection_enabled?, :idor_protection_enabled
+
     # @param request [Rack::Request] a Request object that implements the
     #   Rack::Request API, to which we will delegate behavior.
     # @param settings [Aikido::Zen::RuntimeSettings]
@@ -45,6 +49,7 @@ module Aikido::Zen
       @metadata = {}
       @scanning = false
       @protection_disabled = false
+      @idor_protection_enabled = false
     end
 
     # Fetch some metadata stored in the Context.

--- a/lib/aikido/zen/idor.rb
+++ b/lib/aikido/zen/idor.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "idor/analysis_result"
+require_relative "idor/protector"

--- a/lib/aikido/zen/idor/analysis_result.rb
+++ b/lib/aikido/zen/idor/analysis_result.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+module Aikido::Zen
+  module IDOR
+    class Table
+      def self.from_json(data)
+        new(
+          name: data["name"],
+          alt_name: data["alias"]
+        )
+      end
+
+      # @param name [String]
+      # @param alt_name [String, nil]
+      def initialize(name:, alt_name: nil)
+        @name = name
+        @alt_name = alt_name
+      end
+
+      # @return [String]
+      attr_accessor :name
+      # @return [String, nil]
+      attr_accessor :alt_name
+
+      def ==(other)
+        other.is_a?(self.class) &&
+          other.name == name &&
+          other.alt_name == alt_name
+      end
+      alias_method :eql?, :==
+    end
+
+    class FilterColumn
+      def self.from_json(data)
+        new(
+          table_qualifier: data["table"],
+          name: data["column"],
+          value: data["value"],
+          is_placeholder: data["is_placeholder"],
+          placeholder_number: data["placeholder_number"]
+        )
+      end
+
+      # @param table_qualifier [String, nil]
+      # @param name [String]
+      # @param value [String]
+      # @param is_placeholder [Boolean]
+      # @param placeholder_number [Integer, nil]
+      def initialize(table_qualifier:, name:, value:, is_placeholder:, placeholder_number: nil)
+        @table_qualifier = table_qualifier
+        @name = name
+        @value = value
+        @is_placeholder = is_placeholder
+        @placeholder_number = placeholder_number
+      end
+
+      # @return [String, nil]
+      attr_accessor :table_qualifier
+
+      # @return [String]
+      attr_accessor :name
+
+      # @return [String]
+      attr_accessor :value
+
+      # @return [Boolean]
+      attr_accessor :is_placeholder
+
+      # @return [Integer, nil]
+      attr_accessor :placeholder_number
+
+      def ==(other)
+        other.is_a?(self.class) &&
+          other.table_qualifier == table_qualifier &&
+          other.name == name &&
+          other.value == value &&
+          other.is_placeholder == is_placeholder &&
+          other.placeholder_number == placeholder_number
+      end
+      alias_method :eql?, :==
+    end
+
+    class InsertColumn
+      def self.from_json(data)
+        new(
+          name: data["column"],
+          value: data["value"],
+          is_placeholder: data["is_placeholder"],
+          placeholder_number: data["placeholder_number"]
+        )
+      end
+
+      # @param name [String]
+      # @param value [String]
+      # @param is_placeholder [Boolean]
+      # @param placeholder_number [Integer, nil]
+      def initialize(name:, value:, is_placeholder:, placeholder_number: nil)
+        @name = name
+        @value = value
+        @is_placeholder = is_placeholder
+        @placeholder_number = placeholder_number
+      end
+
+      # @return [String]
+      attr_accessor :name
+
+      # @return [String]
+      attr_accessor :value
+
+      # @return [Boolean]
+      attr_accessor :is_placeholder
+
+      # @return [Integer, nil]
+      attr_accessor :placeholder_number
+
+      def ==(other)
+        other.is_a?(self.class) &&
+          other.name == name &&
+          other.value == value &&
+          other.is_placeholder == is_placeholder &&
+          other.placeholder_number == placeholder_number
+      end
+      alias_method :eql?, :==
+    end
+
+    class SQLQueryResult
+      def self.from_json(data)
+        new(
+          kind: data["kind"].to_sym,
+          tables: data["tables"].map { |value| Table.from_json(value) },
+          filter_columns: data["filters"].map { |value| FilterColumn.from_json(value) },
+          insert_columns: data["insert_columns"]&.map do |values|
+            values.map { |value| InsertColumn.from_json(value) }
+          end
+        )
+      end
+
+      # @param kind [:select, :insert, :update, :delete]
+      # @param tables [Array<Aikido::Zen::IDOR::Table>]
+      # @param filter_columns [Array<Aikido::Zen::IDOR::FilterColumn>]
+      # @param insert_columns [Array<Array<Aikido::Zen::IDOR::InsertColumn>>, nil]
+      def initialize(kind:, tables:, filter_columns:, insert_columns: nil)
+        raise ArgumentError, "kind must be one of :select, :insert, :update, or :delete" unless [:select, :insert, :update, :delete].include?(kind)
+
+        @kind = kind
+        @tables = tables
+        @filter_columns = filter_columns
+        @insert_columns = insert_columns
+      end
+
+      # @return [:select, :insert, :update, :delete]
+      attr_accessor :kind
+
+      # @return [Array<Aikido::Zen::IDOR::Table>]
+      attr_accessor :tables
+
+      # @return [Array<Aikido::Zen::IDOR::FilterColumn>]
+      attr_accessor :filter_columns
+
+      # @return [Array<Array<Aikido::Zen::IDOR::InsertColumn>>, nil]
+      attr_accessor :insert_columns
+
+      def ==(other)
+        other.is_a?(self.class) &&
+          other.kind == kind &&
+          other.tables == tables &&
+          other.filter_columns == filter_columns &&
+          other.insert_columns == insert_columns
+      end
+      alias_method :eql?, :==
+    end
+  end
+end

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -18,10 +18,12 @@ module Aikido::Zen
 
       # @param sql [String]
       # @param dialect_name [Symbol]
-      # @param tenant_id [Integer, String, nil]
+      # @param context [Aikido::Zen::Context]
       # @raise [Aikido::Zen::IDOR::Error]
-      def protect(sql, dialect_name, params, tenant_id, &blk)
-        return unless @config.idor_protection_enabled?
+      def protect(sql, dialect_name, params, context)
+        return unless @config.idor_protection_enabled? && context.idor_protection_enabled?
+
+        tenant_id = context.request.tenant_id
 
         if tenant_id.nil?
           raise Aikido::Zen::IDOR::Error.new("Zen IDOR protection: Aikido::Zen.set_tenant_id was not called for this request. Every request must have a tenant ID when IDOR protection is enabled.")

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -91,7 +91,7 @@ module Aikido::Zen
               raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' is missing column '#{@config.idor_tenant_column_name}'"
             end
 
-            resolved_tenant_id ||= tenant_column.value
+            resolved_tenant_id = tenant_column.value
 
             if tenant_column.is_placeholder
               resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -91,13 +91,15 @@ module Aikido::Zen
               raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' is missing column '#{@config.idor_tenant_column_name}'"
             end
 
-            resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)
-
-            if tenant_column.is_placeholder && !resolved_tenant_id
-              raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' has a placeholder for '#{@config.idor_tenant_column_name}' that could not be resolved"
-            end
-
             resolved_tenant_id ||= tenant_column.value
+
+            if tenant_column.is_placeholder
+              resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)
+
+              unless resolved_tenant_id
+                raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' has a placeholder for '#{@config.idor_tenant_column_name}' that could not be resolved"
+              end
+            end
 
             if resolved_tenant_id.to_s != tenant_id.to_s
               raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' sets '#{@config.idor_tenant_column_name}' to '#{resolved_tenant_id}' but tenant ID is '#{tenant_id}'"
@@ -126,13 +128,15 @@ module Aikido::Zen
             raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' is missing column '#{@config.idor_tenant_column_name}'"
           end
 
-          resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)
+          resolved_tenant_id = tenant_column.value
 
-          if tenant_column.is_placeholder && !resolved_tenant_id
-            raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' has a placeholder for '#{@config.idor_tenant_column_name}' that could not be resolved"
+          if tenant_column.is_placeholder
+            resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)
+
+            unless resolved_tenant_id
+              raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' has a placeholder for '#{@config.idor_tenant_column_name}' that could not be resolved"
+            end
           end
-
-          resolved_tenant_id ||= tenant_column.value
 
           if resolved_tenant_id.to_s != tenant_id.to_s
             raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' sets '#{@config.idor_tenant_column_name}' to '#{resolved_tenant_id}' but tenant ID is '#{tenant_id}'"

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Aikido::Zen
+  module IDOR
+    class Error < StandardError
+    end
+
+    class Protector
+      # @api private
+      # Visible for testing.
+      attr_accessor :cache
+
+      def initialize(config: Aikido::Zen.config)
+        @config = config
+
+        @cache = CappedMap.new(@config.idor_max_cache_entries, mode: :lru)
+      end
+
+      # @param sql [String]
+      # @param dialect_name [Symbol]
+      # @param tenant_id [Integer, String, nil]
+      # @raise [Aikido::Zen::IDOR::Error]
+      def protect(sql, dialect_name, params, tenant_id, &blk)
+        return unless @config.idor_protection_enabled?
+
+        if tenant_id.nil?
+          raise Aikido::Zen::IDOR::Error.new("Zen IDOR protection: Aikido::Zen.set_tenant_id was not called for this request. Every request must have a tenant ID when IDOR protection is enabled.")
+        end
+
+        dialect = Aikido::Zen::SQL::Dialects.fetch(dialect_name)
+
+        analysis = analyze(sql, dialect)
+
+        analysis.each do |query_result|
+          if query_result.kind == :insert
+            protect_insert(dialect, query_result, tenant_id, params)
+          else
+            protect_filter(dialect, query_result, tenant_id, params)
+          end
+        end
+      end
+
+      private
+
+      # @param sql [String]
+      # @param dialect [Aikido::Zen::SQL::Dialects::Dialect]
+      # @return [Array<Aikido::Zen::IDOR::SQLQueryResult>]
+      # @raise [Aikido::Zen::IDOR::Error]
+      def analyze(sql, dialect)
+        analysis = @cache[sql]
+        return analysis if analysis
+
+        analysis = Internals.idor_analyze_sql(sql, dialect)
+
+        # :nocov:
+        unless analysis
+          raise IDOR::Error, "Zen IDOR protection: failed to analyze SQL query"
+        end
+        # :nocov:
+
+        if analysis.is_a?(Hash) && analysis["error"]
+          raise IDOR::Error, "Zen IDOR protection: #{analysis["error"]}"
+        end
+
+        result = analysis.map do |value|
+          Aikido::Zen::IDOR::SQLQueryResult.from_json(value)
+        end
+
+        @cache[sql] = result
+
+        result
+      end
+
+      def protect_insert(dialect, query_result, tenant_id, params)
+        query_result.tables.each do |table|
+          next if @config.idor_excluded_table_names.include?(table.name)
+
+          unless query_result.insert_columns
+            # INSERT ... SELECT without explicit columns — can't verify tenant column
+            raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' is missing column '#{@config.idor_tenant_column_name}'"
+          end
+
+          query_result.insert_columns.each do |row|
+            tenant_column = row.find { |column| column.name == @config.idor_tenant_column_name }
+
+            unless tenant_column
+              raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' is missing column '#{@config.idor_tenant_column_name}'"
+            end
+
+            resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)
+
+            if tenant_column.is_placeholder && !resolved_tenant_id
+              raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' has a placeholder for '#{@config.idor_tenant_column_name}' that could not be resolved"
+            end
+
+            resolved_tenant_id ||= tenant_column.value
+
+            if resolved_tenant_id.to_s != tenant_id.to_s
+              raise IDOR::Error, "Zen IDOR protection: INSERT on table '#{table.name}' sets '#{@config.idor_tenant_column_name}' to '#{resolved_tenant_id}' but tenant ID is '#{tenant_id}'"
+            end
+          end
+        end
+      end
+
+      def protect_filter(dialect, query_result, tenant_id, params)
+        query_result.tables.each do |table|
+          next if @config.idor_excluded_table_names.include?(table.name)
+
+          tenant_column = query_result.filter_columns.find do |column|
+            next false if column.name != @config.idor_tenant_column_name
+
+            next column.table_qualifier == table.name || column.table_qualifier == table.alt_name if column.table_qualifier
+
+            # Unqualified column (e.g. WHERE tenant_id = $1 without table prefix):
+            # We can only safely attribute it to the current table when there's
+            # exactly one table in the query. With multiple tables, we can't know
+            # which table the unqualified column belongs to.
+            query_result.tables.size == 1
+          end
+
+          unless tenant_column
+            raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' is missing column '#{@config.idor_tenant_column_name}'"
+          end
+
+          resolved_tenant_id = dialect.resolve_placeholder(tenant_column.value, tenant_column.placeholder_number, params)
+
+          if tenant_column.is_placeholder && !resolved_tenant_id
+            raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' has a placeholder for '#{@config.idor_tenant_column_name}' that could not be resolved"
+          end
+
+          resolved_tenant_id ||= tenant_column.value
+
+          if resolved_tenant_id.to_s != tenant_id.to_s
+            raise IDOR::Error, "Zen IDOR protection: query on table '#{table.name}' sets '#{@config.idor_tenant_column_name}' to '#{resolved_tenant_id}' but tenant ID is '#{tenant_id}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -49,7 +49,9 @@ module Aikido::Zen
       # @return [Array<Aikido::Zen::IDOR::SQLQueryResult>]
       # @raise [Aikido::Zen::IDOR::Error]
       def analyze(sql, dialect)
-        analysis = @cache[sql]
+        cache_key = [dialect.internals_key, sql]
+
+        analysis = @cache[cache_key]
         return analysis if analysis
 
         analysis = Internals.idor_analyze_sql(sql, dialect)
@@ -68,7 +70,7 @@ module Aikido::Zen
           Aikido::Zen::IDOR::SQLQueryResult.from_json(value)
         end
 
-        @cache[sql] = result
+        @cache[cache_key] = result
 
         result
       end

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -18,8 +18,9 @@ module Aikido::Zen
 
       # @param sql [String]
       # @param dialect_name [Symbol]
+      # @param params [Array, nil]
       # @param context [Aikido::Zen::Context]
-      # @raise [Aikido::Zen::IDOR::Error]
+      # @raise [Aikido::Zen::IDOR::Error, Aikido::Zen::InternalsError]
       def protect(sql, dialect_name, params, context)
         return unless @config.idor_protection_enabled? && context.idor_protection_enabled?
 
@@ -47,7 +48,7 @@ module Aikido::Zen
       # @param sql [String]
       # @param dialect [Aikido::Zen::SQL::Dialects::Dialect]
       # @return [Array<Aikido::Zen::IDOR::SQLQueryResult>]
-      # @raise [Aikido::Zen::IDOR::Error]
+      # @raise [Aikido::Zen::IDOR::Error, Aikido::Zen::InternalsError]
       def analyze(sql, dialect)
         cache_key = [dialect.internals_key, sql]
 

--- a/lib/aikido/zen/internals.rb
+++ b/lib/aikido/zen/internals.rb
@@ -69,6 +69,10 @@ module Aikido::Zen
       #   calling libzen.
       attach_function :detect_sql_injection_native, :detect_sql_injection,
         [:pointer, :size_t, :pointer, :size_t, :int], :int
+
+      attach_function :idor_analyze_sql_native, :idor_analyze_sql_ffi, [:pointer, :size_t, :int], :pointer
+
+      attach_function :idor_free_string_native, :free_string, [:pointer], :void
     rescue LoadError, FFI::NotFoundError => err # rubocop:disable Lint/ShadowedException
       # :nocov:
 
@@ -77,6 +81,11 @@ module Aikido::Zen
 
       def self.detect_sql_injection(query, *)
         attempt = format("%p for SQL injection", query)
+        raise InternalsError.new(attempt, "loading", libzen_name)
+      end
+
+      def self.idor_analyze_sql(query, *)
+        attempt = format("%p for SQL analysis", query)
         raise InternalsError.new(attempt, "loading", libzen_name)
       end
 
@@ -111,6 +120,18 @@ module Aikido::Zen
         end
 
         result
+      end
+
+      def self.idor_analyze_sql(query, dialect)
+        query_bytes = query.encode("UTF-8").bytes
+        buffer = FFI::MemoryPointer.new(:uint8, query_bytes.size)
+        buffer.put_array_of_uint8(0, query_bytes)
+
+        result_ptr = idor_analyze_sql_native(buffer, query_bytes.size, dialect)
+        result_json = result_ptr.read_string
+        idor_free_string_native(result_ptr)
+
+        JSON.parse(result_json)
       end
     end
 

--- a/lib/aikido/zen/internals.rb
+++ b/lib/aikido/zen/internals.rb
@@ -26,10 +26,12 @@ module Aikido::Zen
 
       names << "#{lib_name}-#{platform}.#{lib_ext}"
 
+      # :nocov:
       unless platform.version.nil?
         platform.version = nil
         names << "#{lib_name}-#{platform}.#{lib_ext}"
       end
+      # :nocov:
 
       names
     end
@@ -51,7 +53,9 @@ module Aikido::Zen
           # empty
         end
       end
+      # :nocov:
       raise LoadError, "Zen could not load its native extension #{libzen_name}"
+      # :nocov:
     end
 
     begin

--- a/lib/aikido/zen/internals.rb
+++ b/lib/aikido/zen/internals.rb
@@ -59,7 +59,7 @@ module Aikido::Zen
 
       # @!method self.detect_sql_injection_native(query, input, dialect)
       # @param (see .detect_sql_injection)
-      # @returns [Integer] 0 if no injection detected, 1 if an injection was
+      # @return [Integer] 0 if no injection detected, 1 if an injection was
       #   detected, 2 if there was an internal error, or 3 if SQL tokenization failed.
       # @raise [Aikido::Zen::InternalsError] if there's a problem loading or
       #   calling libzen.
@@ -86,7 +86,7 @@ module Aikido::Zen
       # @param dialect [Integer, #to_int] the SQL Dialect identifier in libzen.
       #   See {Aikido::Zen::Scanners::SQLInjectionScanner::DIALECTS}.
       #
-      # @returns [Boolean]
+      # @return [Boolean]
       # @raise [Aikido::Zen::InternalsError] if there's a problem loading or
       #   calling libzen.
       def self.detect_sql_injection(query, input, dialect)

--- a/lib/aikido/zen/internals.rb
+++ b/lib/aikido/zen/internals.rb
@@ -123,11 +123,11 @@ module Aikido::Zen
       end
 
       def self.idor_analyze_sql(query, dialect)
-        query_bytes = query.encode("UTF-8").bytes
-        buffer = FFI::MemoryPointer.new(:uint8, query_bytes.size)
-        buffer.put_array_of_uint8(0, query_bytes)
+        query_bytes = encode_safely(query)
+        query_ptr = FFI::MemoryPointer.new(:uint8, query_bytes.bytesize)
+        query_ptr.put_bytes(0, query_bytes)
 
-        result_ptr = idor_analyze_sql_native(buffer, query_bytes.size, dialect)
+        result_ptr = idor_analyze_sql_native(query_ptr, query_bytes.bytesize, dialect)
         result_json = result_ptr.read_string
         idor_free_string_native(result_ptr)
 

--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -39,6 +39,10 @@ module Aikido::Zen
       end
 
       ActiveSupport.on_load(:action_controller) do
+        before_action do
+          Aikido::Zen.enable_idor_protection if Aikido::Zen.config.idor_protection_enabled?
+        end
+
         # Due to how Rails sets up its middleware chain, the routing is evaluated
         # (and the Request object constructed) in the app that terminates the
         # chain, so no amount of middleware will be able to access it.

--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -17,6 +17,12 @@ module Aikido::Zen
     # @see Aikido::Zen.track_user
     attr_accessor :actor
 
+    # The current tenant, if set by the host app.
+    #
+    # @return [Integer, String, nil]
+    # @see Aikido::Zen.set_tenant_id
+    attr_accessor :tenant_id
+
     def initialize(delegate, config = Aikido::Zen.config, framework:, router:)
       super(delegate)
       @config = config

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -24,10 +24,7 @@ module Aikido::Zen
       # @return [Aikido::Zen::Attack, nil] an Attack if any user input is
       #   detected to be attempting a SQL injection, or nil if this is safe.
       def self.call(query:, dialect:, scan:, sink:, context:, operation:)
-        dialect = DIALECTS.fetch(dialect) do
-          Aikido::Zen.config.logger.warn "Unknown SQL dialect #{dialect.inspect}"
-          DIALECTS[:common]
-        end
+        dialect = Aikido::Zen::SQL::Dialects.fetch(dialect)
 
         context.payloads.each do |payload|
           scanner = new(query, payload.value.to_s, dialect)
@@ -93,23 +90,6 @@ module Aikido::Zen
 
         raise err
       end
-
-      # @api private
-      Dialect = Struct.new(:name, :internals_key, keyword_init: true) do
-        alias_method :to_s, :name
-        alias_method :to_int, :internals_key
-      end
-
-      # Maps easy-to-use Symbols to a struct that keeps both the name and the
-      # internal identifier used by libzen.
-      #
-      # @see https://github.com/AikidoSec/zen-internals/blob/main/src/sql_injection/helpers/select_dialect_based_on_enum.rs
-      DIALECTS = {
-        common: Dialect.new(name: "SQL", internals_key: 0),
-        mysql: Dialect.new(name: "MySQL", internals_key: 8),
-        postgresql: Dialect.new(name: "PostgreSQL", internals_key: 9),
-        sqlite: Dialect.new(name: "SQLite", internals_key: 12)
-      }
     end
   end
 end

--- a/lib/aikido/zen/sinks/mysql2.rb
+++ b/lib/aikido/zen/sinks/mysql2.rb
@@ -18,8 +18,32 @@ module Aikido::Zen
           ::Mysql2::Client.class_eval do
             extend Sinks::DSL
 
-            sink_before :query do |sql|
-              Helpers.scan(sql, "query")
+            presafe_sink_before :query do |sql|
+              Sinks::DSL.safe do
+                Helpers.scan(sql, "query")
+              end
+
+              Aikido::Zen.idor_protect(sql, :mysql)
+            end
+
+            presafe_sink_after :prepare do |result, sql|
+              result.aikido_idor_sql = sql
+            end
+          end
+
+          ::Mysql2::Statement.class_eval do
+            extend Sinks::DSL
+
+            attr_accessor :aikido_idor_sql
+
+            presafe_sink_before :execute do |*args, **kwargs|
+              sql = aikido_idor_sql
+
+              Sinks::DSL.safe do
+                Helpers.scan(sql, "query")
+              end
+
+              Aikido::Zen.idor_protect(sql, :mysql, args)
             end
           end
         end

--- a/lib/aikido/zen/sinks/pg.rb
+++ b/lib/aikido/zen/sinks/pg.rb
@@ -44,31 +44,63 @@ module Aikido::Zen
 
             [
               :send_query,
-              :exec,
-              :sync_exec,
+              :exec, # also known as: async_exec
               :async_exec,
-              :send_query_params,
-              :exec_params,
-              :sync_exec_params,
-              :async_exec_params
+              :sync_exec
             ].each do |method_name|
-              presafe_sink_before method_name do |query|
+              presafe_sink_before method_name do |sql|
                 Helpers.safe do
-                  Helpers.scan(query, method_name)
+                  Helpers.scan(sql, method_name)
                 end
+
+                Aikido::Zen.idor_protect(sql, :postgresql)
               end
             end
 
             [
+              :send_query_params,
+              :exec_params, # also known as: async_exec_params
+              :async_exec_params,
+              :sync_exec_params
+            ].each do |method_name|
+              presafe_sink_before method_name do |sql, params|
+                Helpers.safe do
+                  Helpers.scan(sql, method_name)
+                end
+
+                Aikido::Zen.idor_protect(sql, :postgresql, params)
+              end
+            end
+
+            def aikido_idor_prepared_statements
+              @aikido_idor_prepared_statements ||= {}
+            end
+
+            [
               :send_prepare,
-              :prepare,
+              :prepare, # also known as: async_prepare
               :async_prepare,
               :sync_prepare
             ].each do |method_name|
-              presafe_sink_before method_name do |_, query|
+              presafe_sink_before method_name do |statement_name, sql|
+                aikido_idor_prepared_statements[statement_name] = sql
+              end
+            end
+
+            [
+              :send_query_prepared,
+              :exec_prepared, # also known as: async_exec_prepared
+              :async_exec_prepared,
+              :sync_exec_prepared
+            ].each do |method_name|
+              presafe_sink_before method_name do |statement_name, params|
+                sql = aikido_idor_prepared_statements[statement_name]
+
                 Helpers.safe do
-                  Helpers.scan(query, method_name)
+                  Helpers.scan(sql, method_name)
                 end
+
+                Aikido::Zen.idor_protect(sql, :postgresql, params)
               end
             end
           end

--- a/lib/aikido/zen/sinks/sqlite3.rb
+++ b/lib/aikido/zen/sinks/sqlite3.rb
@@ -22,19 +22,63 @@ module Aikido::Zen
           ::SQLite3::Database.class_eval do
             extend Sinks::DSL
 
-            private
+            [
+              :execute,
+              :execute_batch
+            ].each do |method_name|
+              presafe_sink_before method_name do |sql, bind_vars|
+                Sinks::DSL.safe do
+                  Helpers.scan(sql, "database.execute")
+                end
+
+                Aikido::Zen.idor_protect(sql, :sqlite)
+              end
+            end
 
             # SQLite3::Database#exec_batch is an internal native private method.
-            sink_before :exec_batch do |sql|
-              Helpers.scan(sql, "exec_batch")
+            presafe_sink_before :exec_batch do |sql, *args, **kwargs|
+              Sinks::DSL.safe do
+                Helpers.scan(sql, "exec_batch")
+              end
+
+              Aikido::Zen.idor_protect(sql, :sqlite)
+            end
+
+            alias_method :prepare__internal_for_aikido_zen, :prepare
+
+            def prepare(*args, **kwargs, &blk)
+              sql, = args
+
+              Sinks::DSL.safe do
+                Helpers.scan(sql, "statement.execute")
+              end
+
+              unless blk
+                result = prepare__internal_for_aikido_zen(*args, **kwargs)
+                result.aikido_idor_sql = sql
+                return result
+              end
+
+              prepare__internal_for_aikido_zen(*args, **kwargs) do |stmt|
+                stmt.aikido_idor_sql = sql
+                blk.call(stmt)
+              end
             end
           end
 
           ::SQLite3::Statement.class_eval do
             extend Sinks::DSL
 
-            sink_before :initialize do |_db, sql|
-              Helpers.scan(sql, "statement.execute")
+            attr_accessor :aikido_idor_sql
+
+            presafe_sink_before :execute do |*bind_vars|
+              sql = aikido_idor_sql
+
+              Sinks::DSL.safe do
+                Helpers.scan(sql, "statement.execute")
+              end
+
+              Aikido::Zen.idor_protect(sql, :sqlite, bind_vars)
             end
           end
         end

--- a/lib/aikido/zen/sinks/sqlite3.rb
+++ b/lib/aikido/zen/sinks/sqlite3.rb
@@ -31,7 +31,7 @@ module Aikido::Zen
                   Helpers.scan(sql, "database.execute")
                 end
 
-                Aikido::Zen.idor_protect(sql, :sqlite)
+                Aikido::Zen.idor_protect(sql, :sqlite, bind_vars)
               end
             end
 

--- a/lib/aikido/zen/sinks/trilogy.rb
+++ b/lib/aikido/zen/sinks/trilogy.rb
@@ -18,8 +18,12 @@ module Aikido::Zen
           ::Trilogy.class_eval do
             extend Sinks::DSL
 
-            sink_before :query do |query|
-              Helpers.scan(query, "query")
+            presafe_sink_before :query do |sql|
+              Sinks::DSL.safe do
+                Helpers.scan(sql, "query")
+              end
+
+              Aikido::Zen.idor_protect(sql, :mysql)
             end
           end
         end

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Aikido::Zen
+  module SQL
+    module Dialects
+      # @api private
+      Dialect = Struct.new(:name, :internals_key, :placeholder_resolver, keyword_init: true) do
+        alias_method :to_s, :name
+        alias_method :to_int, :internals_key
+
+        def resolve_placeholder(*args, **kwargs)
+          placeholder_resolver.call(*args, **kwargs)
+        end
+      end
+
+      COMMON_PLACEHOLDER_RESOLVER = ->(value, placeholder_number, params = []) do
+        params[placeholder_number] unless placeholder_number.nil?
+      end
+
+      POSTGRESQL_PLACEHOLDER_RESOLVER = ->(value, placeholder_number, params = []) do
+        match = value.match(/^\$(\d+)$/)
+        if match && params
+          index = match[1].to_i - 1
+          params[index]
+        end
+      end
+
+      # Maps easy-to-use Symbols to a struct that keeps both the name and the
+      # internal identifier used by libzen.
+      #
+      # @see https://github.com/AikidoSec/zen-internals/blob/main/src/sql_injection/helpers/select_dialect_based_on_enum.rs
+      DIALECTS = {
+        common: Dialect.new(name: "SQL", internals_key: 0, placeholder_resolver: COMMON_PLACEHOLDER_RESOLVER),
+        mysql: Dialect.new(name: "MySQL", internals_key: 8, placeholder_resolver: COMMON_PLACEHOLDER_RESOLVER),
+        postgresql: Dialect.new(name: "PostgreSQL", internals_key: 9, placeholder_resolver: POSTGRESQL_PLACEHOLDER_RESOLVER),
+        sqlite: Dialect.new(name: "SQLite", internals_key: 12, placeholder_resolver: COMMON_PLACEHOLDER_RESOLVER)
+      }.freeze
+
+      # @param dialect [Symbol]
+      # @return [Aikido::Zen::SQL::Dialects::Dialect]
+      def self.fetch(dialect)
+        DIALECTS.fetch(dialect, DIALECTS[:common])
+      end
+    end
+  end
+end

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -25,6 +25,23 @@ module Aikido::Zen
         end
       end
 
+      def self.sqlite_placeholder_resolver(value, placeholder_number, params = [])
+        return params[placeholder_number] unless placeholder_number.nil?
+
+        match = value.match(/^[:@$]([A-Za-z_][A-Za-z0-9_]*)$/)
+        if match
+          key = match[1]
+
+          params.flatten.each do |param|
+            if Hash === param
+              param.each do |param_key, param_value|
+                return param_value if param_key.to_s == key
+              end
+            end
+          end
+        end
+      end
+
       # Maps easy-to-use Symbols to a struct that keeps both the name and the
       # internal identifier used by libzen.
       #
@@ -48,7 +65,7 @@ module Aikido::Zen
         sqlite: Dialect.new(
           name: "SQLite",
           internals_key: 12,
-          placeholder_resolver: method(:common_placeholder_resolver)
+          placeholder_resolver: method(:sqlite_placeholder_resolver)
         )
       }.freeze
 

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -13,11 +13,11 @@ module Aikido::Zen
         end
       end
 
-      COMMON_PLACEHOLDER_RESOLVER = ->(value, placeholder_number, params = []) do
+      def self.common_placeholder_resolver(value, placeholder_number, params = [])
         params[placeholder_number] unless placeholder_number.nil?
       end
 
-      POSTGRESQL_PLACEHOLDER_RESOLVER = ->(value, placeholder_number, params = []) do
+      def self.postgresql_placeholder_resolver(value, placeholder_number, params = [])
         match = value.match(/^\$(\d+)$/)
         if match && params
           index = match[1].to_i - 1
@@ -30,10 +30,26 @@ module Aikido::Zen
       #
       # @see https://github.com/AikidoSec/zen-internals/blob/main/src/sql_injection/helpers/select_dialect_based_on_enum.rs
       DIALECTS = {
-        common: Dialect.new(name: "SQL", internals_key: 0, placeholder_resolver: COMMON_PLACEHOLDER_RESOLVER),
-        mysql: Dialect.new(name: "MySQL", internals_key: 8, placeholder_resolver: COMMON_PLACEHOLDER_RESOLVER),
-        postgresql: Dialect.new(name: "PostgreSQL", internals_key: 9, placeholder_resolver: POSTGRESQL_PLACEHOLDER_RESOLVER),
-        sqlite: Dialect.new(name: "SQLite", internals_key: 12, placeholder_resolver: COMMON_PLACEHOLDER_RESOLVER)
+        common: Dialect.new(
+          name: "SQL",
+          internals_key: 0,
+          placeholder_resolver: method(:common_placeholder_resolver)
+        ),
+        mysql: Dialect.new(
+          name: "MySQL",
+          internals_key: 8,
+          placeholder_resolver: method(:common_placeholder_resolver)
+        ),
+        postgresql: Dialect.new(
+          name: "PostgreSQL",
+          internals_key: 9,
+          placeholder_resolver: method(:postgresql_placeholder_resolver)
+        ),
+        sqlite: Dialect.new(
+          name: "SQLite",
+          internals_key: 12,
+          placeholder_resolver: method(:common_placeholder_resolver)
+        )
       }.freeze
 
       # @param dialect [Symbol]

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -21,6 +21,8 @@ module Aikido::Zen
         match = value.match(/^\$(\d+)$/)
         if match
           index = match[1].to_i - 1
+          return if index < 0
+
           params[index]
         end
       end
@@ -33,6 +35,8 @@ module Aikido::Zen
           match = Regexp.last_match
 
           index = match[1].to_i - 1
+          return if index < 0
+
           params[index]
         when /^[:@$]([A-Za-z_][A-Za-z0-9_]*)$/
           match = Regexp.last_match

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -19,7 +19,7 @@ module Aikido::Zen
 
       def self.postgresql_placeholder_resolver(value, placeholder_number, params = [])
         match = value.match(/^\$(\d+)$/)
-        if match && params
+        if match
           index = match[1].to_i - 1
           params[index]
         end

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -28,8 +28,15 @@ module Aikido::Zen
       def self.sqlite_placeholder_resolver(value, placeholder_number, params = [])
         return params[placeholder_number] unless placeholder_number.nil?
 
-        match = value.match(/^[:@$]([A-Za-z_][A-Za-z0-9_]*)$/)
-        if match
+        case value
+        when /^\?(\d+)$/
+          match = Regexp.last_match
+
+          index = match[1].to_i - 1
+          params[index]
+        when /^[:@$]([A-Za-z_][A-Za-z0-9_]*)$/
+          match = Regexp.last_match
+
           key = match[1]
 
           params.flatten.each do |param|

--- a/lib/aikido/zen/sql.rb
+++ b/lib/aikido/zen/sql.rb
@@ -13,11 +13,23 @@ module Aikido::Zen
         end
       end
 
-      def self.common_placeholder_resolver(value, placeholder_number, params = [])
+      # @param value [String]
+      # @param placeholder_number [Integer, nil]
+      # @param params [Array<Object>, nil]
+      # @return [Object]
+      def self.common_placeholder_resolver(value, placeholder_number, params)
+        return nil unless params
+
         params[placeholder_number] unless placeholder_number.nil?
       end
 
-      def self.postgresql_placeholder_resolver(value, placeholder_number, params = [])
+      # @param value [String]
+      # @param placeholder_number [Integer, nil]
+      # @param params [Array<Object>, nil]
+      # @return [Object]
+      def self.postgresql_placeholder_resolver(value, placeholder_number, params)
+        return nil unless params
+
         match = value.match(/^\$(\d+)$/)
         if match
           index = match[1].to_i - 1
@@ -27,7 +39,13 @@ module Aikido::Zen
         end
       end
 
-      def self.sqlite_placeholder_resolver(value, placeholder_number, params = [])
+      # @param value [String]
+      # @param placeholder_number [Integer, nil]
+      # @param params [Array<Object>, nil]
+      # @return [Object]
+      def self.sqlite_placeholder_resolver(value, placeholder_number, params)
+        return nil unless params
+
         return params[placeholder_number] unless placeholder_number.nil?
 
         case value

--- a/lib/aikido/zen/version.rb
+++ b/lib/aikido/zen/version.rb
@@ -5,6 +5,6 @@ module Aikido
     VERSION = "1.3.1"
 
     # The version of libzen_internals that we build against.
-    LIBZEN_VERSION = "0.1.60"
+    LIBZEN_VERSION = "0.1.61"
   end
 end

--- a/test/aikido/zen/attack_test.rb
+++ b/test/aikido/zen/attack_test.rb
@@ -7,7 +7,7 @@ module Aikido::Zen
     setup do
       @query = "SELECT * FROM users WHERE id = '' OR 1=1 --'"
       @input = Aikido::Zen::Payload.new("' OR 1=1 --", :route, "id")
-      @dialect = Aikido::Zen::Scanners::SQLInjectionScanner::DIALECTS[:common]
+      @dialect = Aikido::Zen::SQL::Dialects.fetch(:common)
       @context = Aikido::Zen::Context.from_rack_env({})
       @op = "test.op"
       @sink = Sink.new("test", scanners: [NOOP])

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -50,6 +50,10 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 10_000, @config.attack_wave_max_cache_entries
     assert_equal 15, @config.attack_wave_max_cache_samples
     assert_equal 1.0, @config.redos_regexp_timeout
+    assert_equal false, @config.idor_protection_enabled?
+    assert_nil @config.idor_tenant_column_name
+    assert_equal [], @config.idor_excluded_table_names
+    assert_equal 1000, @config.idor_max_cache_entries
   end
 
   test "can set AIKIDO_DISABLE to configure if the agent should be turned off" do

--- a/test/aikido/zen/context_test.rb
+++ b/test/aikido/zen/context_test.rb
@@ -119,6 +119,11 @@ class Aikido::Zen::ContextTest < ActiveSupport::TestCase
       context = build_context_for("/path")
       refute context.protection_disabled?
     end
+
+    test "#idor_protection_enabled? is false by default" do
+      context = build_context_for("/path")
+      refute context.idor_protection_enabled?
+    end
   end
 
   class RackRequestTest < ActiveSupport::TestCase

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
+  module GenericTest
+    extend ActiveSupport::Testing::Declarative
+
+    def refute_idor
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+
+      assert_silent do
+        yield
+      end
+    end
+
+    def assert_idor
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+
+      assert_raises(Aikido::Zen::IDOR::Error) do
+        yield
+      end
+    end
+
+    test "IDOR protection is triggered if a context is not set" do
+      err = assert_raises(Aikido::Zen::IDOR::Error) do
+        exec("SELECT * FROM users WHERE tenant_id = 1")
+      end
+
+      assert_equal "Zen IDOR protection: Aikido::Zen.set_tenant_id was not called for this request. Every request must have a tenant ID when IDOR protection is enabled.", err.message
+    end
+
+    test "IDOR protection is triggered if the tenant ID is not set" do
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      err = assert_raises(Aikido::Zen::IDOR::Error) do
+        exec("SELECT * FROM users WHERE tenant_id = 1")
+      end
+
+      assert_equal "Zen IDOR protection: Aikido::Zen.set_tenant_id was not called for this request. Every request must have a tenant ID when IDOR protection is enabled.", err.message
+    end
+
+    test "IDOR protection is triggered for SELECT queries if the tenant ID column does not match the configured tenant ID" do
+      err = assert_idor do
+        exec("SELECT * FROM users WHERE tenant_id = 2")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' sets 'tenant_id' to '2' but tenant ID is '1'", err.message
+    end
+
+    test "IDOR protection is triggered for INSERT queries if the tenant ID column does not match the configured tenant ID" do
+      err = assert_idor do
+        exec("INSERT INTO users (name, tenant_id) VALUES ('John', 2)")
+      end
+
+      assert_equal "Zen IDOR protection: INSERT on table 'users' sets 'tenant_id' to '2' but tenant ID is '1'", err.message
+    end
+
+    test "IDOR protection is not triggered for SELECT queries if the table name is is in the list of excluded table names" do
+      refute_idor do
+        exec("SELECT * FROM roles WHERE name = 'staff'")
+      end
+    end
+
+    test "IDOR protection is not triggered for INSERT queries if the table name is is in the list of excluded table names" do
+      refute_idor do
+        exec("INSERT INTO roles (name) VALUES ('staff')")
+      end
+    end
+
+    test "IDOR protection is triggered if IDOR analyss fails" do
+      err = assert_idor do
+        exec("THIS IS NOT SQL")
+      end
+
+      assert_equal "Zen IDOR protection: sql parser error: Expected: an SQL statement, found: THIS at Line: 1, Column: 1", err.message
+    end
+
+    test "IDOR protection is not triggered for SELECT queries if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("SELECT * FROM users AS u WHERE u.tenant_id = $1")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    # IDOR protection is/is not triggered if the tenant ID column is not/is present
+
+    test "IDOR protection is not triggered for SELECT queries if the tenant ID column is present" do
+      refute_idor do
+        exec("SELECT * FROM users WHERE name = $1 AND tenant_id = $2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is triggered for SELECT queries if the tenant ID column is not present" do
+      assert_idor do
+        exec("SELECT * FROM users WHERE name = $1", ["John"])
+      end
+    end
+
+    test "IDOR protection is not triggered for UPDATE queries if the tenant ID column is present" do
+      refute_idor do
+        exec("UPDATE users SET name = $1 WHERE tenant_id = $2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is triggered for UPDATE queries if the tenant ID column is not present" do
+      assert_idor do
+        exec("UPDATE users SET name = $1", ["John"])
+      end
+    end
+
+    test "IDOR protection is not triggered for DELETE queries if the tenant ID column is present" do
+      refute_idor do
+        exec("DELETE FROM users WHERE name = $1 AND tenant_id = $2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is triggered for DELETE queries if the tenant ID column is not present" do
+      assert_idor do
+        exec("DELETE FROM users WHERE name = $1", ["John"])
+      end
+    end
+
+    test "IDOR protection is not triggered for INSERT queries if the tenant ID column is present" do
+      refute_idor do
+        exec("INSERT INTO users (name, tenant_id) VALUES ('John', $1)", [1])
+      end
+    end
+
+    test "IDOR protection is triggered for INSERT queries if the tenant ID column is not present" do
+      assert_idor do
+        exec("INSERT INTO users (name) VALUES ('John')")
+      end
+    end
+
+    test "IDOR protection is triggered for INSERT queries without insert columns if the tenant ID column is not present" do
+      err = assert_idor do
+        exec("INSERT INTO other SELECT * FROM users WHERE tenant_id = $1", [1])
+      end
+
+      assert_equal "Zen IDOR protection: INSERT on table 'other' is missing column 'tenant_id'", err.message
+    end
+
+    # IDOR protection is triggered if the query has a placeholder that could not be resolved
+
+    test "IDOR protection is triggered for SELECT queries if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("SELECT * FROM users WHERE name = $1 AND tenant_id = $2")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    test "IDOR protection is triggered for UPDATE queries if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("UPDATE users SET name = $1 WHERE tenant_id = $2")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    test "IDOR protection is triggered for DELETE queries if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("DELETE FROM users WHERE name = $1 AND tenant_id = $2")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    test "IDOR protection is triggered for INSERT queries if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("INSERT INTO users (name, tenant_id) VALUES ('John', $1)")
+      end
+
+      assert_equal "Zen IDOR protection: INSERT on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    test "IDOR protection is triggered for INSERT queries without insert columns if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("INSERT INTO other SELECT * FROM users WHERE tenant_id = $1")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    test "IDOR analysis is cached upto Aikido::Zen.config.idor_max_cache_entries" do
+      Aikido::Zen.config.idor_max_cache_entries = 3
+
+      assert_equal 0, Aikido::Zen.idor_protector.cache.size
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+      3.times { exec("SELECT * FROM users WHERE name = 'John' AND tenant_id = 1") }
+      assert_equal 1, Aikido::Zen.idor_protector.cache.size
+
+      Aikido::Zen.set_tenant_id(2)
+      5.times { exec("SELECT * FROM users WHERE name = 'Jane' AND tenant_id = 2") }
+      assert_equal 2, Aikido::Zen.idor_protector.cache.size
+
+      Aikido::Zen.set_tenant_id(3)
+      3.times { exec("SELECT * FROM users WHERE name = 'Alice' AND tenant_id = 3") }
+      assert_equal 3, Aikido::Zen.idor_protector.cache.size
+
+      Aikido::Zen.set_tenant_id(4)
+      5.times { exec("SELECT * FROM users WHERE name = 'Bob' AND tenant_id = 4") }
+      assert_equal 3, Aikido::Zen.idor_protector.cache.size
+    end
+  end
+
+  class MySQLSQLDialectTest < ActiveSupport::TestCase
+    include GenericTest
+
+    def exec(sql, params = [])
+      # Convert PostgreSQL-style placeholders to MySQL-style placeholders.
+      sql = sql.gsub(/\$\d+/, "?")
+
+      Aikido::Zen.idor_protect(sql, :mysql, params)
+    end
+
+    setup do
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+    end
+  end
+
+  class PostgresSQLDialectTest < ActiveSupport::TestCase
+    include GenericTest
+
+    def exec(sql, params = [])
+      Aikido::Zen.idor_protect(sql, :postgresql, params)
+    end
+
+    setup do
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+    end
+  end
+
+  class SQLiteDialectTest < ActiveSupport::TestCase
+    include GenericTest
+
+    def exec(sql, params = [])
+      # Convert PostgreSQL-style placeholders to SQLite-style placeholders.
+      sql = sql.gsub(/\$\d+/, "?")
+
+      Aikido::Zen.idor_protect(sql, :sqlite, params)
+    end
+
+    setup do
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+    end
+  end
+end

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -11,6 +11,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
         Rack::MockRequest.env_for("/")
       )
 
+      Aikido::Zen.enable_idor_protection
       Aikido::Zen.set_tenant_id(1)
 
       assert_silent do
@@ -23,6 +24,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
         Rack::MockRequest.env_for("/")
       )
 
+      Aikido::Zen.enable_idor_protection
       Aikido::Zen.set_tenant_id(1)
 
       assert_raises(Aikido::Zen::IDOR::Error) do
@@ -30,18 +32,23 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
       end
     end
 
-    test "IDOR protection is triggered if a context is not set" do
-      err = assert_raises(Aikido::Zen::IDOR::Error) do
+    test "IDOR protection is not triggered if a context is not set" do
+      assert_nil Aikido::Zen.current_context
+
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.set_tenant_id(1)
+
+      assert_silent do
         exec("SELECT * FROM users WHERE tenant_id = 1")
       end
-
-      assert_equal "Zen IDOR protection: Aikido::Zen.set_tenant_id was not called for this request. Every request must have a tenant ID when IDOR protection is enabled.", err.message
     end
 
     test "IDOR protection is triggered if the tenant ID is not set" do
       Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
         Rack::MockRequest.env_for("/")
       )
+
+      Aikido::Zen.enable_idor_protection
 
       err = assert_raises(Aikido::Zen::IDOR::Error) do
         exec("SELECT * FROM users WHERE tenant_id = 1")
@@ -203,6 +210,8 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
         Rack::MockRequest.env_for("/")
       )
 
+      Aikido::Zen.enable_idor_protection
+
       Aikido::Zen.set_tenant_id(1)
       3.times { exec("SELECT * FROM users WHERE name = 'John' AND tenant_id = 1") }
       assert_equal 1, Aikido::Zen.idor_protector.cache.size
@@ -232,7 +241,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
     end
 
     setup do
-      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_protection_enabled = true
       Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
       Aikido::Zen.config.idor_excluded_table_names = ["roles"]
     end
@@ -246,7 +255,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
     end
 
     setup do
-      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_protection_enabled = true
       Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
       Aikido::Zen.config.idor_excluded_table_names = ["roles"]
     end
@@ -263,7 +272,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
     end
 
     setup do
-      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_protection_enabled = true
       Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
       Aikido::Zen.config.idor_excluded_table_names = ["roles"]
     end

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -255,10 +255,40 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
       Aikido::Zen.idor_protect(sql, :sqlite, params)
     end
 
+    def exec_raw(sql, params = [])
+      Aikido::Zen.idor_protect(sql, :sqlite, params)
+    end
+
     setup do
       Aikido::Zen.config.idor_protection_enabled = true
       Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
       Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+    end
+
+    [":", "@", "$"].each do |prefix|
+      test "IDOR protection is not triggered for SELECT queries using #{prefix}AAA placeholder syntax because placeholders are resolved" do
+        refute_idor do
+          exec("SELECT * FROM users WHERE name = #{prefix}name AND tenant_id = #{prefix}tenant_id", [{name: "John", tenant_id: 1}])
+        end
+      end
+
+      test "IDOR protection is not triggered for UPDATE queries using #{prefix}AAA placeholder syntax because placeholders are resolved" do
+        refute_idor do
+          exec("UPDATE users SET name = #{prefix}name WHERE tenant_id = #{prefix}tenant_id", [{name: "John", tenant_id: 1}])
+        end
+      end
+
+      test "IDOR protection is not triggered for DELETE queries using #{prefix}AAA placeholder syntax because placeholders are resolved" do
+        refute_idor do
+          exec("DELETE FROM users WHERE name = #{prefix}name AND tenant_id = #{prefix}tenant_id", [{name: "John", tenant_id: 1}])
+        end
+      end
+
+      test "IDOR protection is not triggered for INSERT queries using #{prefix}AAA placeholder syntax because placeholders are resolved" do
+        refute_idor do
+          exec("INSERT INTO users (name, tenant_id) VALUES (#{prefix}name, #{prefix}tenant_id)", [{name: "John", tenant_id: 1}])
+        end
+      end
     end
   end
 

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -273,6 +273,30 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
       Aikido::Zen.config.idor_excluded_table_names = ["roles"]
     end
 
+    test "IDOR protection is not triggered for SELECT queries using ?NNN placeholder syntax because placeholders are resolved" do
+      refute_idor do
+        exec("SELECT * FROM users WHERE name = ?1 AND tenant_id = ?2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is not triggered for UPDATE queries using ?NNN placeholder syntax because placeholders are resolved" do
+      refute_idor do
+        exec("UPDATE users SET name = ?1 WHERE tenant_id = ?2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is not triggered for DELETE queries using ?NNN placeholder syntax because placeholders are resolved" do
+      refute_idor do
+        exec("DELETE FROM users WHERE name = ?1 AND tenant_id = ?2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is not triggered for INSERT queries using ?NNN placeholder syntax because placeholders are resolved" do
+      refute_idor do
+        exec("INSERT INTO users (name, tenant_id) VALUES (?1, ?2)", ["John", 1])
+      end
+    end
+
     [":", "@", "$"].each do |prefix|
       test "IDOR protection is not triggered for SELECT queries using #{prefix}AAA placeholder syntax because placeholders are resolved" do
         refute_idor do

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -200,34 +200,6 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
 
       assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
     end
-
-    test "IDOR analysis is cached upto Aikido::Zen.config.idor_max_cache_entries" do
-      Aikido::Zen.config.idor_max_cache_entries = 3
-
-      assert_equal 0, Aikido::Zen.idor_protector.cache.size
-
-      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
-        Rack::MockRequest.env_for("/")
-      )
-
-      Aikido::Zen.enable_idor_protection
-
-      Aikido::Zen.set_tenant_id(1)
-      3.times { exec("SELECT * FROM users WHERE name = 'John' AND tenant_id = 1") }
-      assert_equal 1, Aikido::Zen.idor_protector.cache.size
-
-      Aikido::Zen.set_tenant_id(2)
-      5.times { exec("SELECT * FROM users WHERE name = 'Jane' AND tenant_id = 2") }
-      assert_equal 2, Aikido::Zen.idor_protector.cache.size
-
-      Aikido::Zen.set_tenant_id(3)
-      3.times { exec("SELECT * FROM users WHERE name = 'Alice' AND tenant_id = 3") }
-      assert_equal 3, Aikido::Zen.idor_protector.cache.size
-
-      Aikido::Zen.set_tenant_id(4)
-      5.times { exec("SELECT * FROM users WHERE name = 'Bob' AND tenant_id = 4") }
-      assert_equal 3, Aikido::Zen.idor_protector.cache.size
-    end
   end
 
   class MySQLSQLDialectTest < ActiveSupport::TestCase
@@ -275,6 +247,76 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
       Aikido::Zen.config.idor_protection_enabled = true
       Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
       Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+    end
+  end
+
+  class CacheTest < ActiveSupport::TestCase
+    def exec(sql, dialect_name)
+      Aikido::Zen.idor_protect(sql, dialect_name)
+    end
+
+    def assert_cached(sql, dialect_name)
+      dialect = Aikido::Zen::SQL::Dialects.fetch(dialect_name)
+
+      cache_key = [dialect.internals_key, sql]
+
+      exec(sql, dialect_name)
+
+      assert Aikido::Zen.idor_protector.cache.key?(cache_key)
+    end
+
+    setup do
+      Aikido::Zen.config.idor_protection_enabled = true
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+    end
+
+    test "IDOR analysis results are cached using the SQL and dialect as cache key upto Aikido::Zen.config.idor_max_cache_entries" do
+      Aikido::Zen.config.idor_max_cache_entries = 3
+
+      assert_equal 0, Aikido::Zen.idor_protector.cache.size
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.enable_idor_protection
+
+      assert_equal 0, Aikido::Zen.idor_protector.cache.size
+
+      Aikido::Zen.set_tenant_id(1)
+
+      assert_cached "SELECT * FROM users WHERE name = 'John' AND tenant_id = 1", :postgresql
+
+      Aikido::Zen.set_tenant_id(2)
+
+      assert_difference -> { Aikido::Zen.idor_protector.cache.size }, +1 do
+        5.times do
+          assert_cached "SELECT * FROM users WHERE name = 'Jane' AND tenant_id = 2", :postgresql
+        end
+      end
+
+      assert_difference -> { Aikido::Zen.idor_protector.cache.size }, +1 do
+        3.times do
+          assert_cached "SELECT * FROM users WHERE name = 'Jane' AND tenant_id = 2", :sqlite
+        end
+      end
+
+      Aikido::Zen.set_tenant_id(3)
+
+      assert_difference -> { Aikido::Zen.idor_protector.cache.size }, 0 do
+        3.times do
+          assert_cached "SELECT * FROM users WHERE name = 'Alice' AND tenant_id = 3", :sqlite
+        end
+      end
+
+      Aikido::Zen.set_tenant_id(4)
+
+      assert_difference -> { Aikido::Zen.idor_protector.cache.size }, 0 do
+        3.times do
+          assert_cached "SELECT * FROM users WHERE name = 'Bob' AND tenant_id = 4", :postgresql
+        end
+      end
     end
   end
 end

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -145,7 +145,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
 
     test "IDOR protection is not triggered for INSERT queries if the tenant ID column is present" do
       refute_idor do
-        exec("INSERT INTO users (name, tenant_id) VALUES ('John', $1)", [1])
+        exec("INSERT INTO users (name, tenant_id) VALUES ($1, $2)", ["John", 1])
       end
     end
 
@@ -155,9 +155,17 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
       end
     end
 
+    test "IDOR protection is not triggered for INSERT queries without insert columns if the tenant ID column is not present" do
+      err = assert_idor do
+        exec("INSERT INTO other SELECT * FROM users WHERE name = $1", ["John"])
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' is missing column 'tenant_id'", err.message
+    end
+
     test "IDOR protection is triggered for INSERT queries without insert columns if the tenant ID column is not present" do
       err = assert_idor do
-        exec("INSERT INTO other SELECT * FROM users WHERE tenant_id = $1", [1])
+        exec("INSERT INTO other SELECT * FROM users WHERE name = $1 AND tenant_id = $2", ["John", 1])
       end
 
       assert_equal "Zen IDOR protection: INSERT on table 'other' is missing column 'tenant_id'", err.message
@@ -199,7 +207,7 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
 
     test "IDOR protection is triggered for INSERT queries if the query has a placeholder that could not be resolved" do
       err = assert_idor do
-        exec("INSERT INTO users (name, tenant_id) VALUES ('John', $1)")
+        exec("INSERT INTO users (name, tenant_id) VALUES ($1, $2)")
       end
 
       assert_equal "Zen IDOR protection: INSERT on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message

--- a/test/aikido/zen/idor/protector_test.rb
+++ b/test/aikido/zen/idor/protector_test.rb
@@ -93,14 +93,6 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
       assert_equal "Zen IDOR protection: sql parser error: Expected: an SQL statement, found: THIS at Line: 1, Column: 1", err.message
     end
 
-    test "IDOR protection is not triggered for SELECT queries if the query has a placeholder that could not be resolved" do
-      err = assert_idor do
-        exec("SELECT * FROM users AS u WHERE u.tenant_id = $1")
-      end
-
-      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
-    end
-
     # IDOR protection is/is not triggered if the tenant ID column is not/is present
 
     test "IDOR protection is not triggered for SELECT queries if the tenant ID column is present" do
@@ -112,6 +104,18 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
     test "IDOR protection is triggered for SELECT queries if the tenant ID column is not present" do
       assert_idor do
         exec("SELECT * FROM users WHERE name = $1", ["John"])
+      end
+    end
+
+    test "IDOR protection is not triggered for SELECT queries with table aliases if the tenant ID column is present" do
+      refute_idor do
+        exec("SELECT * FROM users AS u WHERE u.name = $1 AND u.tenant_id = $2", ["John", 1])
+      end
+    end
+
+    test "IDOR protection is triggered for SELECT queries with table aliases if the tenant ID column is not present" do
+      assert_idor do
+        exec("SELECT * FROM users AS u WHERE u.name = $1", ["John"])
       end
     end
 
@@ -164,6 +168,14 @@ class Aikido::Zen::IDOR::ProtectorTest < ActiveSupport::TestCase
     test "IDOR protection is triggered for SELECT queries if the query has a placeholder that could not be resolved" do
       err = assert_idor do
         exec("SELECT * FROM users WHERE name = $1 AND tenant_id = $2")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message
+    end
+
+    test "IDOR protection is triggered for SELECT queries with table aliases if the query has a placeholder that could not be resolved" do
+      err = assert_idor do
+        exec("SELECT * FROM users AS u WHERE u.name = $1 AND u.tenant_id = $2")
       end
 
       assert_equal "Zen IDOR protection: query on table 'users' has a placeholder for 'tenant_id' that could not be resolved", err.message

--- a/test/aikido/zen/idor_test.rb
+++ b/test/aikido/zen/idor_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Aikido::IDORTest < ActiveSupport::TestCase
+  Table = Aikido::Zen::IDOR::Table
+  FilterColumn = Aikido::Zen::IDOR::FilterColumn
+  InsertColumn = Aikido::Zen::IDOR::InsertColumn
+  SQLQueryResult = Aikido::Zen::IDOR::SQLQueryResult
+
+  class SQLQueryResultTest < ActiveSupport::TestCase
+    test ".from_json deserializes SELECT queries" do
+      data = [
+        {
+          "kind" => "select",
+          "tables" => [
+            {
+              "name" => "users",
+              "alias" => "u"
+            }
+          ],
+          "filters" => [
+            {
+              "table" => "u",
+              "column" => "tenant_id",
+              "value" => "$1",
+              "is_placeholder" => true
+            }
+          ]
+        }
+      ]
+
+      expected = [
+        SQLQueryResult.new(
+          kind: :select,
+          tables: [
+            Table.new(
+              name: "users",
+              alt_name: "u"
+            )
+          ],
+          filter_columns: [
+            FilterColumn.new(
+              table_qualifier: "u",
+              name: "tenant_id",
+              value: "$1",
+              is_placeholder: true
+            )
+          ]
+        )
+      ]
+
+      actual = data.map do |value|
+        SQLQueryResult.from_json(value)
+      end
+
+      assert_equal expected, actual
+    end
+
+    test ".from_json deserializes INSERT queries" do
+      data = [
+        {
+          "kind" => "insert",
+          "tables" => [
+            {
+              "name" => "users"
+            }
+          ],
+          "filters" => [],
+          "insert_columns" => [
+            [
+              {
+                "column" => "name",
+                "value" => "John",
+                "is_placeholder" => false
+              },
+              {
+                "column" => "tenant_id",
+                "value" => "$1",
+                "is_placeholder" => true
+              }
+            ]
+          ]
+        }
+      ]
+
+      expected = [
+        SQLQueryResult.new(
+          kind: :insert,
+          tables: [
+            Table.new(
+              name: "users"
+            )
+          ],
+          filter_columns: [],
+          insert_columns: [
+            [
+              InsertColumn.new(
+                name: "name",
+                value: "John",
+                is_placeholder: false
+              ),
+              InsertColumn.new(
+                name: "tenant_id",
+                value: "$1",
+                is_placeholder: true
+              )
+            ]
+          ]
+        )
+      ]
+
+      actual = data.map do |value|
+        SQLQueryResult.from_json(value)
+      end
+
+      assert_equal expected, actual
+    end
+
+    test "#initialize raises ArgumentError if kind is not one of :select, :insert, :update, or :delete" do
+      [:select, :insert, :update, :delete].each do |kind|
+        assert_silent do
+          SQLQueryResult.new(
+            kind: kind,
+            tables: [],
+            filter_columns: [],
+            insert_columns: []
+          )
+        end
+      end
+
+      ["select", :INSERT, "UPDATE", :other, 123].each do |kind|
+        err = assert_raises(ArgumentError) do
+          SQLQueryResult.new(
+            kind: kind,
+            tables: [],
+            filter_columns: [],
+            insert_columns: []
+          )
+        end
+
+        assert_equal "kind must be one of :select, :insert, :update, or :delete", err.message
+      end
+    end
+  end
+end

--- a/test/aikido/zen/internals_test.rb
+++ b/test/aikido/zen/internals_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Aikido::InternalsTest < ActiveSupport::TestCase
+  Internals = Aikido::Zen::Internals
+
+  test "it has a libzen version number" do
+    refute_nil Aikido::Zen::LIBZEN_VERSION
+  end
+
+  test ".detect_sql_injection_native is attached" do
+    assert Internals.singleton_methods.include?(:detect_sql_injection_native)
+  end
+
+  test ".detect_sql_injection is defined" do
+    assert Internals.methods.include?(:detect_sql_injection)
+  end
+
+  test ".detect_sql_injection can detect SQL injection" do
+    assert Internals.detect_sql_injection(
+      "SELECT * FROM users WHERE id = '' OR 1=1 -- '",
+      "' OR 1=1 -- ",
+      Aikido::Zen::SQL::Dialects.fetch(:mysql)
+    )
+  end
+
+  test ".idor_analyze_sql_native is attached" do
+    assert Internals.singleton_methods.include?(:idor_analyze_sql_native)
+  end
+
+  test ".idor_free_string_native is attached" do
+    assert Internals.singleton_methods.include?(:idor_free_string_native)
+  end
+
+  test ".idor_analyze_sql is defined" do
+    assert Internals.methods.include?(:idor_analyze_sql)
+  end
+
+  test ".idor_analyze_sql can analyze SELECT queries" do
+    result = Internals.idor_analyze_sql("SELECT * FROM users u WHERE u.tenant_id = $1", 9)
+    assert_equal(
+      [
+        {
+          "kind" => "select",
+          "tables" => [
+            {
+              "name" => "users",
+              "alias" => "u"
+            }
+          ],
+          "filters" => [
+            {
+              "table" => "u",
+              "column" => "tenant_id",
+              "value" => "$1",
+              "is_placeholder" => true
+            }
+          ]
+        }
+      ],
+      result
+    )
+  end
+
+  test ".idor_analyze_sql can analyze INSERT queries" do
+    result = Internals.idor_analyze_sql("INSERT INTO users (name, tenant_id) VALUES ('John', $1)", 9)
+    assert_equal(
+      [
+        {
+          "kind" => "insert",
+          "tables" => [
+            {
+              "name" => "users"
+            }
+          ],
+          "filters" => [],
+          "insert_columns" => [
+            [
+              {
+                "column" => "name",
+                "value" => "John",
+                "is_placeholder" => false
+              },
+              {
+                "column" => "tenant_id",
+                "value" => "$1",
+                "is_placeholder" => true
+              }
+            ]
+          ]
+        }
+      ],
+      result
+    )
+  end
+
+  test ".idor_analyze_sql returns a parse error value when the query cannot be parsed" do
+    result = Internals.idor_analyze_sql("THIS IS NOT SQL", Aikido::Zen::SQL::Dialects.fetch(:mysql))
+
+    assert_equal(
+      {"error" => "sql parser error: Expected: an SQL statement, found: THIS at Line: 1, Column: 1"},
+      result
+    )
+  end
+end

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -13,7 +13,7 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     end
 
     def scan(query, input = query, dialect = :common)
-      dialect = Aikido::Zen::Scanners::SQLInjectionScanner::DIALECTS.fetch(dialect)
+      dialect = Aikido::Zen::SQL::Dialects.fetch(dialect)
       Aikido::Zen::Scanners::SQLInjectionScanner.new(query, input, dialect).attack?
     end
   end

--- a/test/aikido/zen/sinks/mysql2_test.rb
+++ b/test/aikido/zen/sinks/mysql2_test.rb
@@ -54,7 +54,7 @@ class Aikido::Zen::Sinks::Mysql2Test < ActiveSupport::TestCase
   class IDORTest < ActiveSupport::TestCase
     def with_mocked_protector(params = [])
       mock = Minitest::Mock.new
-      mock.expect(:protect, nil, [String, :mysql, params, 1])
+      mock.expect(:protect, nil, [String, :mysql, params, Aikido::Zen::Context])
 
       original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
       Aikido::Zen.instance_variable_set(:@idor_protector, mock)
@@ -79,7 +79,7 @@ class Aikido::Zen::Sinks::Mysql2Test < ActiveSupport::TestCase
         password: ENV.fetch("MYSQL_PASSWORD", "")
       )
 
-      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_protection_enabled = true
     end
 
     test "#query includes IDOR protection" do

--- a/test/aikido/zen/sinks/mysql2_test.rb
+++ b/test/aikido/zen/sinks/mysql2_test.rb
@@ -94,5 +94,24 @@ class Aikido::Zen::Sinks::Mysql2Test < ActiveSupport::TestCase
         statement.execute(1)
       end
     end
+
+    test "IDOR protection is triggered by complete example" do
+      Aikido::Zen.config.idor_protection_enabled = true
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.set_tenant_id(1)
+
+      err = assert_raises(Aikido::Zen::IDOR::Error) do
+        @db.query("SELECT * FROM users WHERE name = 'John'")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' is missing column 'tenant_id'", err.message
+    end
   end
 end

--- a/test/aikido/zen/sinks/mysql2_test.rb
+++ b/test/aikido/zen/sinks/mysql2_test.rb
@@ -50,4 +50,49 @@ class Aikido::Zen::Sinks::Mysql2Test < ActiveSupport::TestCase
       @db.query "SELECT 1 WHERE 1 = '1'' OR ''''='''';--'"
     end
   end
+
+  class IDORTest < ActiveSupport::TestCase
+    def with_mocked_protector(params = [])
+      mock = Minitest::Mock.new
+      mock.expect(:protect, nil, [String, :mysql, params, 1])
+
+      original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
+      Aikido::Zen.instance_variable_set(:@idor_protector, mock)
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+
+      yield
+
+      assert_mock mock
+    ensure
+      Aikido::Zen.instance_variable_set(:@idor_protector, original_protector)
+    end
+
+    setup do
+      @db = Mysql2::Client.new(
+        host: ENV.fetch("MYSQL_HOST", "127.0.0.1"),
+        username: ENV.fetch("MYSQL_USERNAME", "root"),
+        password: ENV.fetch("MYSQL_PASSWORD", "")
+      )
+
+      Aikido::Zen.enable_idor_protection
+    end
+
+    test "#query includes IDOR protection" do
+      with_mocked_protector do
+        @db.query("SELECT 1")
+      end
+    end
+
+    test "#prepare and #execute includes IDOR protection" do
+      with_mocked_protector([1]) do
+        statement = @db.prepare("SELECT ?")
+        statement.execute(1)
+      end
+    end
+  end
 end

--- a/test/aikido/zen/sinks/mysql2_test.rb
+++ b/test/aikido/zen/sinks/mysql2_test.rb
@@ -52,7 +52,7 @@ class Aikido::Zen::Sinks::Mysql2Test < ActiveSupport::TestCase
   end
 
   class IDORTest < ActiveSupport::TestCase
-    def with_mocked_protector(params = [])
+    def with_mocked_protector(params = nil)
       mock = Minitest::Mock.new
       mock.expect(:protect, nil, [String, :mysql, params, Aikido::Zen::Context])
 

--- a/test/aikido/zen/sinks/pg_test.rb
+++ b/test/aikido/zen/sinks/pg_test.rb
@@ -17,15 +17,17 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
     @sink = Aikido::Zen::Sinks::PG::SINK
   end
 
-  def with_mocked_scanner(for_operation:, &b)
+  def with_mocked_scanner(for_operation:, &blk)
     mock = Minitest::Mock.new
-    mock.expect :call, nil,
+    mock.expect(
+      :call, nil,
       query: String,
       dialect: :postgresql,
       scan: Aikido::Zen::Scan,
       sink: @sink,
       operation: for_operation,
       context: Aikido::Zen::Context
+    )
 
     mock.expect :skips_on_nil_context?, true
 
@@ -37,6 +39,7 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
   test "scans queries via #send_query" do
     with_mocked_scanner for_operation: :send_query do |mock|
       @db.send_query("SELECT 1")
+      while @db.get_result; end
 
       assert_mock mock
     end
@@ -50,14 +53,6 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
     end
   end
 
-  test "scans queries via #sync_exec" do
-    with_mocked_scanner for_operation: :sync_exec do |mock|
-      @db.sync_exec("SELECT 1")
-
-      assert_mock mock
-    end
-  end
-
   test "scans queries via #async_exec" do
     with_mocked_scanner for_operation: :async_exec do |mock|
       @db.async_exec("SELECT 1")
@@ -66,9 +61,18 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
     end
   end
 
+  test "scans queries via #sync_exec" do
+    with_mocked_scanner for_operation: :sync_exec do |mock|
+      @db.sync_exec("SELECT 1")
+
+      assert_mock mock
+    end
+  end
+
   test "scans queries via #send_query_params" do
     with_mocked_scanner for_operation: :send_query_params do |mock|
       @db.send_query_params("SELECT $1", ["1"])
+      while @db.get_result; end
 
       assert_mock mock
     end
@@ -82,14 +86,6 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
     end
   end
 
-  test "scans queries via #sync_exec_params" do
-    with_mocked_scanner for_operation: :sync_exec_params do |mock|
-      @db.sync_exec_params("SELECT $1", ["1"])
-
-      assert_mock mock
-    end
-  end
-
   test "scans queries via #async_exec_params" do
     with_mocked_scanner for_operation: :async_exec_params do |mock|
       @db.async_exec_params("SELECT $1", ["1"])
@@ -98,33 +94,102 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
     end
   end
 
-  test "scans queries via #send_prepare" do
-    with_mocked_scanner for_operation: :send_prepare do |mock|
-      @db.send_prepare("name", "SELECT 1")
+  test "scans queries via #sync_exec_params" do
+    with_mocked_scanner for_operation: :sync_exec_params do |mock|
+      @db.sync_exec_params("SELECT $1", ["1"])
 
       assert_mock mock
     end
   end
 
-  test "scans queries via #prepare" do
-    with_mocked_scanner for_operation: :prepare do |mock|
-      @db.prepare("name", "SELECT 1")
+  test "scans queries via #send_prepare and #exec_prepared" do
+    @db.send_prepare("name", "SELECT 1")
+    while @db.get_result; end
+
+    with_mocked_scanner for_operation: :exec_prepared do |mock|
+      @db.exec_prepared("name")
 
       assert_mock mock
     end
   end
 
-  test "scans queries via #async_prepare" do
-    with_mocked_scanner for_operation: :async_prepare do |mock|
-      @db.async_prepare("name", "SELECT 1")
+  test "scans queries via #send_prepare and #async_exec_prepared" do
+    @db.send_prepare("name", "SELECT 1")
+    while @db.get_result; end
+
+    with_mocked_scanner for_operation: :async_exec_prepared do |mock|
+      @db.async_exec_prepared("name")
 
       assert_mock mock
     end
   end
 
-  test "scans queries via #sync_prepare" do
-    with_mocked_scanner for_operation: :sync_prepare do |mock|
-      @db.sync_prepare("name", "SELECT 1")
+  test "scans queries via #send_prepare and #sync_exec_prepared" do
+    @db.send_prepare("name", "SELECT 1")
+    while @db.get_result; end
+
+    with_mocked_scanner for_operation: :sync_exec_prepared do |mock|
+      @db.sync_exec_prepared("name")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #prepare and #exec_prepared" do
+    @db.prepare("name", "SELECT 1")
+
+    with_mocked_scanner for_operation: :exec_prepared do |mock|
+      @db.exec_prepared("name")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #prepare and #async_exec_prepared" do
+    @db.prepare("name", "SELECT 1")
+
+    with_mocked_scanner for_operation: :async_exec_prepared do |mock|
+      @db.async_exec_prepared("name")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #prepare and #sync_exec_prepared" do
+    @db.prepare("name", "SELECT 1")
+
+    with_mocked_scanner for_operation: :sync_exec_prepared do |mock|
+      @db.sync_exec_prepared("name")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #sync_prepare and #exec_prepared" do
+    @db.sync_prepare("name", "SELECT 1")
+
+    with_mocked_scanner for_operation: :exec_prepared do |mock|
+      @db.exec_prepared("name")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #sync_prepare and #async_exec_prepared" do
+    @db.sync_prepare("name", "SELECT 1")
+
+    with_mocked_scanner for_operation: :async_exec_prepared do |mock|
+      @db.async_exec_prepared("name")
+
+      assert_mock mock
+    end
+  end
+
+  test "scans queries via #sync_prepare and #sync_exec_prepared" do
+    @db.sync_prepare("name", "SELECT 1")
+
+    with_mocked_scanner for_operation: :sync_exec_prepared do |mock|
+      @db.sync_exec_prepared("name")
 
       assert_mock mock
     end
@@ -135,6 +200,7 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
 
     assert_attack Aikido::Zen::Attacks::SQLInjectionAttack do
       @db.send_query "SELECT 1 WHERE 1 = '1' OR ''='';--'"
+      while @db.get_result; end
     end
   end
 
@@ -143,6 +209,122 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
 
     refute_attack do
       @db.send_query "SELECT 1 WHERE 1 = '1'' OR ''''='''';--'"
+      while @db.get_result; end
+    end
+  end
+
+  class IDORTest < ActiveSupport::TestCase
+    def with_mocked_protector(params = [])
+      mock = Minitest::Mock.new
+      mock.expect(:protect, nil, [String, :postgresql, params, 1])
+
+      original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
+      Aikido::Zen.instance_variable_set(:@idor_protector, mock)
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+
+      yield
+
+      assert_mock mock
+    ensure
+      Aikido::Zen.instance_variable_set(:@idor_protector, original_protector)
+    end
+
+    setup do
+      @db = PG.connect(
+        host: ENV.fetch("POSTGRES_HOST", "127.0.0.1"),
+        user: ENV.fetch("POSTGRES_USERNAME", "postgres"),
+        password: ENV.fetch("POSTGRES_PASSWORD", "password"),
+        dbname: ENV.fetch("POSTGRES_DATABASE", "postgres")
+      )
+
+      Aikido::Zen.enable_idor_protection
+    end
+
+    test "#send_query includes IDOR protection" do
+      with_mocked_protector do
+        @db.send_query("SELECT 1")
+        while @db.get_result; end
+      end
+    end
+
+    test "#exec includes IDOR protection" do
+      with_mocked_protector do
+        @db.exec("SELECT 1")
+      end
+    end
+
+    test "#async_exec includes IDOR protection" do
+      with_mocked_protector do
+        @db.async_exec("SELECT 1")
+      end
+    end
+
+    test "#sync_exec includes IDOR protection" do
+      with_mocked_protector do
+        @db.sync_exec("SELECT 1")
+      end
+    end
+
+    test "#send_query_params includes IDOR protection" do
+      with_mocked_protector([1]) do
+        @db.send_query_params("SELECT $1", [1])
+        while @db.get_result; end
+      end
+    end
+
+    test "#exec_params includes IDOR protection" do
+      with_mocked_protector([1]) do
+        @db.exec_params("SELECT $1", [1])
+      end
+    end
+
+    test "#async_exec_params includes IDOR protection" do
+      with_mocked_protector([1]) do
+        @db.async_exec_params("SELECT $1", [1])
+      end
+    end
+
+    test "#sync_exec_params includes IDOR protection" do
+      with_mocked_protector([1]) do
+        @db.sync_exec_params("SELECT $1", [1])
+      end
+    end
+
+    [
+      :send_prepare,
+      :prepare,
+      :sync_prepare
+    ].each do |prepare_method_name|
+      [
+        :send_query_prepared,
+        :exec_prepared,
+        :sync_exec_prepared
+      ].each do |exec_method_name|
+        test "##{prepare_method_name} and ##{exec_method_name} includes IDOR protection" do
+          sql = "SELECT $1"
+
+          name = "name_for_#{prepare_method_name}_and_#{exec_method_name}"
+
+          @db.send(prepare_method_name, name, sql)
+          if prepare_method_name == :send_prepare
+            while @db.get_result; end
+          end
+
+          assert_equal sql, @db.aikido_idor_prepared_statements[name]
+
+          with_mocked_protector([1]) do
+            @db.send(exec_method_name, name, [1])
+            if exec_method_name == :send_query_prepared
+              while @db.get_result; end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/test/aikido/zen/sinks/pg_test.rb
+++ b/test/aikido/zen/sinks/pg_test.rb
@@ -326,5 +326,24 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
         end
       end
     end
+
+    test "IDOR protection is triggered by complete example" do
+      Aikido::Zen.config.idor_protection_enabled = true
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.set_tenant_id(1)
+
+      err = assert_raises(Aikido::Zen::IDOR::Error) do
+        @db.exec("SELECT * FROM users WHERE name = 'John'")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' is missing column 'tenant_id'", err.message
+    end
   end
 end

--- a/test/aikido/zen/sinks/pg_test.rb
+++ b/test/aikido/zen/sinks/pg_test.rb
@@ -216,7 +216,7 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
   class IDORTest < ActiveSupport::TestCase
     def with_mocked_protector(params = [])
       mock = Minitest::Mock.new
-      mock.expect(:protect, nil, [String, :postgresql, params, 1])
+      mock.expect(:protect, nil, [String, :postgresql, params, Aikido::Zen::Context])
 
       original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
       Aikido::Zen.instance_variable_set(:@idor_protector, mock)
@@ -242,7 +242,7 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
         dbname: ENV.fetch("POSTGRES_DATABASE", "postgres")
       )
 
-      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_protection_enabled = true
     end
 
     test "#send_query includes IDOR protection" do

--- a/test/aikido/zen/sinks/pg_test.rb
+++ b/test/aikido/zen/sinks/pg_test.rb
@@ -214,7 +214,7 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
   end
 
   class IDORTest < ActiveSupport::TestCase
-    def with_mocked_protector(params = [])
+    def with_mocked_protector(params = nil)
       mock = Minitest::Mock.new
       mock.expect(:protect, nil, [String, :postgresql, params, Aikido::Zen::Context])
 

--- a/test/aikido/zen/sinks/sqlite3_test.rb
+++ b/test/aikido/zen/sinks/sqlite3_test.rb
@@ -29,7 +29,7 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
   end
 
   test "scans queries via #execute" do
-    with_mocked_scanner for_operation: "statement.execute" do |mock|
+    with_mocked_scanner for_operation: "database.execute" do |mock|
       @db.execute("SELECT 1")
 
       assert_mock mock
@@ -45,7 +45,7 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
   end
 
   test "scans queries via #execute_batch" do
-    with_mocked_scanner for_operation: "statement.execute" do |mock|
+    with_mocked_scanner for_operation: "database.execute" do |mock|
       @db.execute_batch("SELECT 1")
 
       assert_mock mock
@@ -64,9 +64,9 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
     with_mocked_scanner for_operation: "statement.execute" do |mock|
       @db.prepare("SELECT 1") do |statement|
         statement.execute
-
-        assert_mock mock
       end
+
+      assert_mock mock
     end
   end
 
@@ -83,6 +83,67 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
 
     refute_attack do
       @db.execute "SELECT 1 WHERE 1 = '1'' OR ''''='''';--'"
+    end
+  end
+
+  class IDORTest < ActiveSupport::TestCase
+    def with_mocked_protector(params = [])
+      mock = Minitest::Mock.new
+      mock.expect(:protect, nil, [String, :sqlite, params, 1])
+
+      original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
+      Aikido::Zen.instance_variable_set(:@idor_protector, mock)
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+
+      yield
+
+      assert_mock mock
+    ensure
+      Aikido::Zen.instance_variable_set(:@idor_protector, original_protector)
+    end
+
+    setup do
+      @db = SQLite3::Database.new(":memory:")
+
+      Aikido::Zen.enable_idor_protection
+    end
+
+    test "#execute includes IDOR protection" do
+      with_mocked_protector do
+        @db.execute("SELECT 1")
+      end
+    end
+
+    test "#execute_batch includes IDOR protection" do
+      with_mocked_protector do
+        @db.execute_batch("SELECT 1")
+      end
+    end
+
+    test "#execute_batch2 includes IDOR protection" do
+      with_mocked_protector do
+        @db.execute_batch2("SELECT 1")
+      end
+    end
+
+    test "#prepare and #execute with block includes IDOR protection" do
+      with_mocked_protector([1]) do
+        @db.prepare("SELECT ?") do |statement|
+          statement.execute(1)
+        end
+      end
+    end
+
+    test "#prepare and #execute without block includes IDOR protection" do
+      with_mocked_protector([1]) do
+        statement = @db.prepare("SELECT ?")
+        statement.execute(1)
+      end
     end
   end
 end

--- a/test/aikido/zen/sinks/sqlite3_test.rb
+++ b/test/aikido/zen/sinks/sqlite3_test.rb
@@ -145,5 +145,24 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
         statement.execute(1)
       end
     end
+
+    test "IDOR protection is triggered by complete example" do
+      Aikido::Zen.config.idor_protection_enabled = true
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.set_tenant_id(1)
+
+      err = assert_raises(Aikido::Zen::IDOR::Error) do
+        @db.execute("SELECT * FROM users WHERE name = 'John'")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' is missing column 'tenant_id'", err.message
+    end
   end
 end

--- a/test/aikido/zen/sinks/sqlite3_test.rb
+++ b/test/aikido/zen/sinks/sqlite3_test.rb
@@ -89,7 +89,7 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
   class IDORTest < ActiveSupport::TestCase
     def with_mocked_protector(params = [])
       mock = Minitest::Mock.new
-      mock.expect(:protect, nil, [String, :sqlite, params, 1])
+      mock.expect(:protect, nil, [String, :sqlite, params, Aikido::Zen::Context])
 
       original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
       Aikido::Zen.instance_variable_set(:@idor_protector, mock)
@@ -110,7 +110,7 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
     setup do
       @db = SQLite3::Database.new(":memory:")
 
-      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.config.idor_protection_enabled = true
     end
 
     test "#execute includes IDOR protection" do

--- a/test/aikido/zen/sinks/sqlite3_test.rb
+++ b/test/aikido/zen/sinks/sqlite3_test.rb
@@ -87,7 +87,7 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
   end
 
   class IDORTest < ActiveSupport::TestCase
-    def with_mocked_protector(params = [])
+    def with_mocked_protector(params = nil)
       mock = Minitest::Mock.new
       mock.expect(:protect, nil, [String, :sqlite, params, Aikido::Zen::Context])
 
@@ -114,14 +114,14 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
     end
 
     test "#execute includes IDOR protection" do
-      with_mocked_protector do
-        @db.execute("SELECT 1")
+      with_mocked_protector([1]) do
+        @db.execute("SELECT ?", [1])
       end
     end
 
     test "#execute_batch includes IDOR protection" do
-      with_mocked_protector do
-        @db.execute_batch("SELECT 1")
+      with_mocked_protector([1]) do
+        @db.execute_batch("SELECT 1", [1])
       end
     end
 

--- a/test/aikido/zen/sinks/trilogy_test.rb
+++ b/test/aikido/zen/sinks/trilogy_test.rb
@@ -50,4 +50,40 @@ class Aikido::Zen::Sinks::TrilogyTest < ActiveSupport::TestCase
       @db.query "SELECT 1 WHERE 1 = '1'' OR ''''='''';--'"
     end
   end
+
+  class IDORTest < ActiveSupport::TestCase
+    def with_mocked_protector(params = [])
+      mock = Minitest::Mock.new
+      mock.expect(:protect, nil, [String, :mysql, params, 1])
+
+      original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
+      Aikido::Zen.instance_variable_set(:@idor_protector, mock)
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.set_tenant_id(1)
+
+      yield
+
+      assert_mock mock
+    ensure
+      Aikido::Zen.instance_variable_set(:@idor_protector, original_protector)
+    end
+
+    setup do
+      @db = Trilogy.new(
+        host: ENV.fetch("MYSQL_HOST", "127.0.0.1"),
+        username: ENV.fetch("MYSQL_USERNAME", "root"),
+        password: ENV.fetch("MYSQL_PASSWORD", "")
+      )
+    end
+
+    test "#query includes IDOR protection" do
+      with_mocked_protector do
+        @db.query("SELECT 1")
+      end
+    end
+  end
 end

--- a/test/aikido/zen/sinks/trilogy_test.rb
+++ b/test/aikido/zen/sinks/trilogy_test.rb
@@ -87,5 +87,24 @@ class Aikido::Zen::Sinks::TrilogyTest < ActiveSupport::TestCase
         @db.query("SELECT 1")
       end
     end
+
+    test "IDOR protection is triggered by complete example" do
+      Aikido::Zen.config.idor_protection_enabled = true
+      Aikido::Zen.config.idor_tenant_column_name = "tenant_id"
+      Aikido::Zen.config.idor_excluded_table_names = ["roles"]
+
+      Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+        Rack::MockRequest.env_for("/")
+      )
+
+      Aikido::Zen.enable_idor_protection
+      Aikido::Zen.set_tenant_id(1)
+
+      err = assert_raises(Aikido::Zen::IDOR::Error) do
+        @db.query("SELECT * FROM users WHERE name = 'John'")
+      end
+
+      assert_equal "Zen IDOR protection: query on table 'users' is missing column 'tenant_id'", err.message
+    end
   end
 end

--- a/test/aikido/zen/sinks/trilogy_test.rb
+++ b/test/aikido/zen/sinks/trilogy_test.rb
@@ -54,7 +54,7 @@ class Aikido::Zen::Sinks::TrilogyTest < ActiveSupport::TestCase
   class IDORTest < ActiveSupport::TestCase
     def with_mocked_protector(params = [])
       mock = Minitest::Mock.new
-      mock.expect(:protect, nil, [String, :mysql, params, 1])
+      mock.expect(:protect, nil, [String, :mysql, params, Aikido::Zen::Context])
 
       original_protector = Aikido::Zen.instance_variable_get(:@idor_protector)
       Aikido::Zen.instance_variable_set(:@idor_protector, mock)
@@ -78,6 +78,8 @@ class Aikido::Zen::Sinks::TrilogyTest < ActiveSupport::TestCase
         username: ENV.fetch("MYSQL_USERNAME", "root"),
         password: ENV.fetch("MYSQL_PASSWORD", "")
       )
+
+      Aikido::Zen.config.idor_protection_enabled = true
     end
 
     test "#query includes IDOR protection" do

--- a/test/aikido/zen/sinks/trilogy_test.rb
+++ b/test/aikido/zen/sinks/trilogy_test.rb
@@ -52,7 +52,7 @@ class Aikido::Zen::Sinks::TrilogyTest < ActiveSupport::TestCase
   end
 
   class IDORTest < ActiveSupport::TestCase
-    def with_mocked_protector(params = [])
+    def with_mocked_protector(params = nil)
       mock = Minitest::Mock.new
       mock.expect(:protect, nil, [String, :mysql, params, Aikido::Zen::Context])
 

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -63,37 +63,51 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     end
   end
 
-  test ".enable_idor_protection enables IDOR protection" do
-    Aikido::Zen.config.idor_protection_enabled = false
+  test ".idor_protect does not fail if context is not set" do
+    assert_nil Aikido::Zen.current_context
 
-    assert_equal false, Aikido::Zen.config.idor_protection_enabled
+    assert_silent do
+      Aikido::Zen.idor_protect("SELECT 1", :common)
+    end
+  end
+
+  test ".enable_idor_protection enables IDOR protection" do
+    context = Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+      Rack::MockRequest.env_for("/")
+    )
+
+    assert_equal false, context.idor_protection_enabled
 
     Aikido::Zen.enable_idor_protection
 
-    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+    assert_equal true, context.idor_protection_enabled
   end
 
-  test ".disable_idor_protection enables IDOR protection" do
-    Aikido::Zen.config.idor_protection_enabled = true
+  test ".enable_idor_protection does not fail if context is not set" do
+    assert_nil Aikido::Zen.current_context
 
-    assert_equal true, Aikido::Zen.config.idor_protection_enabled
-
-    Aikido::Zen.disable_idor_protection
-
-    assert_equal false, Aikido::Zen.config.idor_protection_enabled
+    assert_silent do
+      Aikido::Zen.enable_idor_protection
+    end
   end
 
   test ".without_idor_protection executes a block with IDOR protection disabled" do
-    Aikido::Zen.config.idor_protection_enabled = true
+    context = Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+      Rack::MockRequest.env_for("/")
+    )
 
-    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+    assert_equal false, context.idor_protection_enabled
+
+    Aikido::Zen.enable_idor_protection
+
+    assert_equal true, context.idor_protection_enabled
 
     result = Aikido::Zen.without_idor_protection do
-      assert_equal false, Aikido::Zen.config.idor_protection_enabled
+      assert_equal false, context.idor_protection_enabled
       :result
     end
 
-    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+    assert_equal true, context.idor_protection_enabled
 
     assert_equal :result, result
   end

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -42,4 +42,77 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     assert_equal "123", actor.id
     assert_equal "Alice", actor.name
   end
+
+  test ".set_tenant_id sets the tenant on the request" do
+    context = Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env(
+      Rack::MockRequest.env_for("/")
+    )
+
+    assert_nil context.request.tenant_id
+
+    Aikido::Zen.set_tenant_id("1")
+
+    assert_equal "1", context.request.tenant_id
+  end
+
+  test ".set_tenant_id does not fail if context is not set" do
+    assert_nil Aikido::Zen.current_context
+
+    assert_silent do
+      Aikido::Zen.set_tenant_id(1)
+    end
+  end
+
+  test ".enable_idor_protection enables IDOR protection" do
+    Aikido::Zen.config.idor_protection_enabled = false
+
+    assert_equal false, Aikido::Zen.config.idor_protection_enabled
+
+    Aikido::Zen.enable_idor_protection
+
+    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+  end
+
+  test ".disable_idor_protection enables IDOR protection" do
+    Aikido::Zen.config.idor_protection_enabled = true
+
+    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+
+    Aikido::Zen.disable_idor_protection
+
+    assert_equal false, Aikido::Zen.config.idor_protection_enabled
+  end
+
+  test ".without_idor_protection executes a block with IDOR protection disabled" do
+    Aikido::Zen.config.idor_protection_enabled = true
+
+    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+
+    result = Aikido::Zen.without_idor_protection do
+      assert_equal false, Aikido::Zen.config.idor_protection_enabled
+      :result
+    end
+
+    assert_equal true, Aikido::Zen.config.idor_protection_enabled
+
+    assert_equal :result, result
+  end
+
+  test ".without_idor_protection executes the block even if context is not set" do
+    assert_nil Aikido::Zen.current_context
+
+    result = Aikido::Zen.without_idor_protection do
+      :result
+    end
+
+    assert_equal :result, result
+  end
+
+  test ".without_idor_protection raises ArgumentError if no block is given" do
+    err = assert_raises(ArgumentError) do
+      Aikido::Zen.without_idor_protection
+    end
+
+    assert_equal "block required", err.message
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -80,6 +80,7 @@ class ActiveSupport::TestCase
     Aikido::Zen.detached_agent.instance_variable_set(:@rate_limiter, Aikido::Zen::RateLimiter.new)
 
     Aikido::Zen.instance_variable_set(:@attack_wave_detector, nil)
+    Aikido::Zen.instance_variable_set(:@idor_protector, nil)
 
     Aikido::Zen.current_context = nil
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,6 +79,8 @@ class ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@runtime_settings, nil)
     Aikido::Zen.detached_agent.instance_variable_set(:@rate_limiter, Aikido::Zen::RateLimiter.new)
 
+    Aikido::Zen.instance_variable_set(:@attack_wave_detector, nil)
+
     Aikido::Zen.current_context = nil
 
     Aikido::Zen.singleton_class.remove_method(:track_scan)


### PR DESCRIPTION
This change provides IDOR protection during development, for the supported database drivers (currently `mysql2`, `pg`, `sqlite3`, and `trilogy`).

Some effort has been spent to add missing sink methods, however, the APIs are large and that effort was not exhaustive.

This change includes several cleanup commits at the start, collected during development, which were considered too small to justify a separate PR.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 10 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added IDOR protection feature with analysis and enforcement logic

**⚡ Enhancements**
* Integrated IDOR checks into multiple DB sinks for query execution
* Introduced SQL dialect abstraction with placeholder resolving logic
* Extended native Internals FFI with idor_analyze and safe encoding
* Added tenant_id and helpers to Context/Request to enable protection

**🔧 Refactors**
* Bumped libzen version and applied various small doc and coverage tweaks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/113721929?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->