### PR TITLE
Add support for excluded user ids during rate limiting

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -63,7 +63,7 @@ jobs:
           cat Dockerfile
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@v1.0.11
+        uses: AikidoSec/firewall-tester-action@v1.0.12
         with:
           dockerfile_path: ./zen-demo-ruby/Dockerfile
           app_port: 3000

--- a/lib/aikido/zen/middleware/rack_throttler.rb
+++ b/lib/aikido/zen/middleware/rack_throttler.rb
@@ -38,6 +38,8 @@ module Aikido::Zen
       def should_throttle?(request)
         return false if @settings.bypassed_ips.include?(request.client_ip)
 
+        return false if request.actor && @settings.user_excluded_from_rate_limiting?(request.actor.id)
+
         return false unless @settings.endpoints[request.route].rate_limiting.enabled?
 
         result = @detached_agent.calculate_rate_limits(request)

--- a/lib/aikido/zen/runtime_settings.rb
+++ b/lib/aikido/zen/runtime_settings.rb
@@ -11,7 +11,7 @@ module Aikido::Zen
   #
   # You can subscribe to changes with +#add_observer(object, func_name)+, which
   # will call the function passing the settings as an argument
-  RuntimeSettings = Struct.new(:updated_at, :heartbeat_interval, :endpoints, :blocked_user_ids, :bypassed_ips, :received_any_stats, :blocking_mode, :blocked_user_agent_regexp, :monitored_user_agent_regexp, :user_agent_details, :blocked_ip_lists, :allowed_ip_lists, :monitored_ip_lists, :block_new_outbound, :domains) do
+  RuntimeSettings = Struct.new(:updated_at, :heartbeat_interval, :endpoints, :blocked_user_ids, :bypassed_ips, :received_any_stats, :blocking_mode, :blocked_user_agent_regexp, :monitored_user_agent_regexp, :user_agent_details, :blocked_ip_lists, :allowed_ip_lists, :monitored_ip_lists, :block_new_outbound, :domains, :excluded_user_ids_from_rate_limiting) do
     def initialize(*)
       super
       self.endpoints ||= RuntimeSettings::Endpoints.new
@@ -20,6 +20,7 @@ module Aikido::Zen
       self.allowed_ip_lists ||= []
       self.monitored_ip_lists ||= []
       self.domains ||= RuntimeSettings::Domains.new
+      self.excluded_user_ids_from_rate_limiting ||= Set.new
     end
 
     # @!attribute [rw] updated_at
@@ -69,6 +70,10 @@ module Aikido::Zen
     # @!attribute [rw] domains
     #   @return [Array<Aikido::Zen::RuntimeSettings::DomainSettings>]
 
+    # @!attribute [rw] excluded_user_ids_from_rate_limiting
+    #   @return [Set<String>] the set of user IDs that should be skipped from
+    #     rate limiting entirely.
+
     # Parse and interpret the JSON response from the core API with updated
     # runtime settings, and apply the changes.
     #
@@ -90,6 +95,8 @@ module Aikido::Zen
 
       self.block_new_outbound = data["blockNewOutgoingRequests"]
       self.domains = RuntimeSettings::Domains.from_json(data["domains"])
+
+      self.excluded_user_ids_from_rate_limiting = Array(data["excludedUserIdsFromRateLimiting"]).map(&:to_s).to_set
 
       updated_at != last_updated_at
     end
@@ -159,6 +166,13 @@ module Aikido::Zen
     # @return [Boolean] Whether the IP is included in the bypassed IPs set.
     def bypassed_ip?(ip)
       bypassed_ips.include?(ip)
+    end
+
+    # @param user_id [String, nil]
+    # @return [Boolean] Whether the user is excluded from rate limiting.
+    def user_excluded_from_rate_limiting?(user_id)
+      return false if user_id.nil?
+      excluded_user_ids_from_rate_limiting.include?(user_id.to_s)
     end
 
     # @param user_agent [String] the user agent

--- a/lib/aikido/zen/runtime_settings.rb
+++ b/lib/aikido/zen/runtime_settings.rb
@@ -20,7 +20,6 @@ module Aikido::Zen
       self.allowed_ip_lists ||= []
       self.monitored_ip_lists ||= []
       self.domains ||= RuntimeSettings::Domains.new
-      self.excluded_user_ids_from_rate_limiting ||= Set.new
     end
 
     # @!attribute [rw] updated_at
@@ -71,7 +70,7 @@ module Aikido::Zen
     #   @return [Array<Aikido::Zen::RuntimeSettings::DomainSettings>]
 
     # @!attribute [rw] excluded_user_ids_from_rate_limiting
-    #   @return [Set<String>] the set of user IDs that should be skipped from
+    #   @return [Array<String>, nil] the user IDs that should be skipped from
     #     rate limiting entirely.
 
     # Parse and interpret the JSON response from the core API with updated
@@ -96,7 +95,7 @@ module Aikido::Zen
       self.block_new_outbound = data["blockNewOutgoingRequests"]
       self.domains = RuntimeSettings::Domains.from_json(data["domains"])
 
-      self.excluded_user_ids_from_rate_limiting = Array(data["excludedUserIdsFromRateLimiting"]).map(&:to_s).to_set
+      self.excluded_user_ids_from_rate_limiting = data["excludedUserIdsFromRateLimiting"]
 
       updated_at != last_updated_at
     end
@@ -172,7 +171,7 @@ module Aikido::Zen
     # @return [Boolean] Whether the user is excluded from rate limiting.
     def user_excluded_from_rate_limiting?(user_id)
       return false if user_id.nil?
-      excluded_user_ids_from_rate_limiting.include?(user_id.to_s)
+      excluded_user_ids_from_rate_limiting&.include?(user_id.to_s) || false
     end
 
     # @param user_agent [String] the user agent

--- a/lib/aikido/zen/sinks/action_controller.rb
+++ b/lib/aikido/zen/sinks/action_controller.rb
@@ -53,6 +53,8 @@ module Aikido::Zen
         end
 
         private def should_throttle?(request)
+          return false if request.actor && @settings.user_excluded_from_rate_limiting?(request.actor.id)
+
           return false unless @settings.endpoints[request.route].rate_limiting.enabled?
 
           result = @detached_agent.calculate_rate_limits(request)

--- a/test/aikido/zen/middleware/rack_throttler_test.rb
+++ b/test/aikido/zen/middleware/rack_throttler_test.rb
@@ -117,6 +117,51 @@ class Aikido::Zen::Middleware::RackThrottlerTest < ActiveSupport::TestCase
     assert_mock @app
   end
 
+  test "does not block requests or annotate the env for excluded users" do
+    @settings.excluded_user_ids_from_rate_limiting = Set["user-1"]
+
+    configure "GET", "/", max_requests: 3, period: 5
+
+    @app.expect :call, [200, {}, ["OK"]], [Hash]
+    @app.expect :call, [200, {}, ["OK"]], [Hash]
+    @app.expect :call, [200, {}, ["OK"]], [Hash]
+
+    env = Rack::MockRequest.env_for("/", "REMOTE_ADDR" => "1.2.3.4")
+
+    context = Aikido::Zen::Context.from_rack_env(env)
+    context.request.actor = Aikido::Zen::Actor.new(id: "user-1")
+    Aikido::Zen.current_context = context
+
+    4.times do
+      assert_equal [200, {}, ["OK"]], @middleware.call(env)
+    end
+
+    refute env.key?("aikido.rate_limiting")
+    assert_mock @app
+  ensure
+    Aikido::Zen.current_context = nil
+  end
+
+  test "rate limits requests for users not in the excluded set" do
+    @settings.excluded_user_ids_from_rate_limiting = Set["user-1"]
+
+    configure "GET", "/", max_requests: 1, period: 5
+
+    env = Rack::MockRequest.env_for("/", "REMOTE_ADDR" => "1.2.3.4")
+
+    context = Aikido::Zen::Context.from_rack_env(env)
+    context.request.actor = Aikido::Zen::Actor.new(id: "user-2")
+    Aikido::Zen.current_context = context
+
+    assert_equal [200, {}, ["OK"]], @middleware.call(env)
+
+    response = @middleware.call(env)
+    assert_equal 429, response[0]
+    assert_mock @app
+  ensure
+    Aikido::Zen.current_context = nil
+  end
+
   test "the throttled response can be configured" do
     @config.rate_limited_responder = ->(request) {
       [503, {}, ["Oh no you broke the server!"]]

--- a/test/aikido/zen/runtime_settings_test.rb
+++ b/test/aikido/zen/runtime_settings_test.rb
@@ -110,17 +110,12 @@ class Aikido::Zen::RuntimeSettingsTest < ActiveSupport::TestCase
     refute @settings.user_excluded_from_rate_limiting?("user3")
   end
 
-  test "#user_excluded_from_rate_limiting? coerces ids to strings" do
-    @settings.update_from_runtime_config_json({
-      "excludedUserIdsFromRateLimiting" => [42]
-    })
-
-    assert @settings.user_excluded_from_rate_limiting?(42)
-    assert @settings.user_excluded_from_rate_limiting?("42")
-  end
-
   test "#user_excluded_from_rate_limiting? returns false for nil" do
     refute @settings.user_excluded_from_rate_limiting?(nil)
+  end
+
+  test "#user_excluded_from_rate_limiting? returns false when the list is nil" do
+    refute @settings.user_excluded_from_rate_limiting?("user1")
   end
 
   test "#update_from_runtime_config_json replaces the excluded user ids set" do

--- a/test/aikido/zen/runtime_settings_test.rb
+++ b/test/aikido/zen/runtime_settings_test.rb
@@ -100,6 +100,53 @@ class Aikido::Zen::RuntimeSettingsTest < ActiveSupport::TestCase
     refute @settings.update_from_runtime_config_json(payload)
   end
 
+  test "#update_from_runtime_config_json populates excluded_user_ids_from_rate_limiting" do
+    @settings.update_from_runtime_config_json({
+      "excludedUserIdsFromRateLimiting" => ["user1", "user2"]
+    })
+
+    assert @settings.user_excluded_from_rate_limiting?("user1")
+    assert @settings.user_excluded_from_rate_limiting?("user2")
+    refute @settings.user_excluded_from_rate_limiting?("user3")
+  end
+
+  test "#user_excluded_from_rate_limiting? coerces ids to strings" do
+    @settings.update_from_runtime_config_json({
+      "excludedUserIdsFromRateLimiting" => [42]
+    })
+
+    assert @settings.user_excluded_from_rate_limiting?(42)
+    assert @settings.user_excluded_from_rate_limiting?("42")
+  end
+
+  test "#user_excluded_from_rate_limiting? returns false for nil" do
+    refute @settings.user_excluded_from_rate_limiting?(nil)
+  end
+
+  test "#update_from_runtime_config_json replaces the excluded user ids set" do
+    @settings.update_from_runtime_config_json({
+      "excludedUserIdsFromRateLimiting" => ["user1", "user2"]
+    })
+    @settings.update_from_runtime_config_json({
+      "excludedUserIdsFromRateLimiting" => ["user3"]
+    })
+
+    refute @settings.user_excluded_from_rate_limiting?("user1")
+    refute @settings.user_excluded_from_rate_limiting?("user2")
+    assert @settings.user_excluded_from_rate_limiting?("user3")
+  end
+
+  test "#update_from_runtime_config_json with an empty array clears the excluded user ids" do
+    @settings.update_from_runtime_config_json({
+      "excludedUserIdsFromRateLimiting" => ["user1"]
+    })
+    @settings.update_from_runtime_config_json({
+      "excludedUserIdsFromRateLimiting" => []
+    })
+
+    refute @settings.user_excluded_from_rate_limiting?("user1")
+  end
+
   test "#bypassed_ips lets you use individual addresses" do
     assert @settings.update_from_runtime_config_json({
       "allowedIPAddresses" => ["1.2.3.4", "2.3.4.5"]

--- a/test/aikido/zen/sinks/action_controller_test.rb
+++ b/test/aikido/zen/sinks/action_controller_test.rb
@@ -285,6 +285,31 @@ class Aikido::Zen::Sinks::ActionControllerTest < ActiveSupport::TestCase
     end
   end
 
+  test "excluded users are not rate limited" do
+    Aikido::Zen.runtime_settings.excluded_user_ids_from_rate_limiting = ["excluded-1"]
+    configure "GET", "/", max_requests: 2, period: 10
+
+    5.times do
+      Aikido::Zen.current_context = nil
+      excluded = build_request("GET", "/", ip: "1.2.3.4", user: {id: "excluded-1"})
+      refute_throttled_or_blocked make_request(excluded)
+    end
+
+    Aikido::Zen.current_context = nil
+    other_1 = build_request("GET", "/", ip: "1.2.3.4", user: {id: "other"})
+    refute_throttled_or_blocked make_request(other_1)
+
+    Aikido::Zen.current_context = nil
+    other_2 = build_request("GET", "/", ip: "1.2.3.4", user: {id: "other"})
+    refute_throttled_or_blocked make_request(other_2)
+
+    Aikido::Zen.current_context = nil
+    other_3 = build_request("GET", "/", ip: "1.2.3.4", user: {id: "other"})
+    assert_throttled make_request(other_3)
+  ensure
+    Aikido::Zen.runtime_settings.excluded_user_ids_from_rate_limiting = nil
+  end
+
   test "requests are blocked if the user is in the blocking list" do
     Aikido::Zen.runtime_settings.blocked_user_ids = ["1234"]
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added excluded_user_ids_from_rate_limiting setting and parsed it from API
* Implemented user_excluded_from_rate_limiting? helper to check exclusions by id string
* Skipped rate limiting for excluded users in Rack middleware and controller
* Bumped firewall-tester-action in QA workflow to v1.0.12 for tests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103312580?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->