### PR TITLE
Verify release tag matches gem version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,34 @@ on:
     types: [published]
 
 jobs:
+  verify-version:
+    name: 🔖 Verify tag matches gem version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check tag against Aikido::Zen::VERSION
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gem_version=$(grep -E '^\s*VERSION\s*=' lib/aikido/zen/version.rb | sed -E 's/.*"([^"]+)".*/\1/')
+          expected="v${gem_version}"
+          if [ "$TAG" != "$expected" ]; then
+            echo "::error::Release tag '$TAG' does not match Aikido::Zen::VERSION ('$gem_version'). Expected tag '$expected'."
+            exit 1
+          fi
+          echo "Tag '$TAG' matches Aikido::Zen::VERSION ('$gem_version')."
   unit-tests:
     name: 🧪 Unit tests
+    needs: verify-version
     uses: ./.github/workflows/unit-test.yml
     secrets: inherit
   lint:
     name: 🧹 Lint code
+    needs: verify-version
     uses: ./.github/workflows/lint.yml
   e2e:
     name: 🕵️ End to end tests
+    needs: verify-version
     uses: ./.github/workflows/e2e.yml
   release:
     runs-on: ubuntu-latest
@@ -24,6 +43,7 @@ jobs:
       id-token: write
 
     needs:
+      - verify-version
       - unit-tests
       - lint
       - e2e


### PR DESCRIPTION
## Summary
- Adds a `verify-version` job to `release.yml` that compares `github.event.release.tag_name` against `Aikido::Zen::VERSION` and fails fast if they don't match.
- Gates `unit-tests`, `lint`, `e2e`, and `release` on the new job so nothing is built or pushed when the tag and constant disagree.

## Why
`v1.2.0` was published as a GitHub release without bumping `lib/aikido/zen/version.rb`, so RubyGems received a gem whose version did not match the tag. This guard would have caught it.

## Test plan
- [ ] After merge, the next release (v1.2.1) runs `verify-version` and passes (tag `v1.2.1` matches `VERSION = "1.2.1"`).
- [ ] Mentally verify the negative path: against `VERSION = "1.1.2"` and tag `v1.2.0`, the step would have errored before any gem was pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added verify-version job to validate release tag matched gem version


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103624070?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->