### PR TITLE
Temporarily disable loading IP lists from core while perf issues are being fixed

### DIFF
--- a/lib/aikido/zen/runtime_settings.rb
+++ b/lib/aikido/zen/runtime_settings.rb
@@ -125,23 +125,12 @@ module Aikido::Zen
         }
       end
 
+      # Temporarily disabled: loading blocked/allowed/monitored IP lists from
+      # core is O(N) per request in IPListChecker and causes CPU spikes with
+      # large lists. Keep the lists empty so the middleware short-circuits.
       self.blocked_ip_lists = []
-
-      data["blockedIPAddresses"]&.each do |ip_list|
-        blocked_ip_lists << RuntimeSettings::IPList.from_json(ip_list)
-      end
-
       self.allowed_ip_lists = []
-
-      data["allowedIPAddresses"]&.each do |ip_list|
-        allowed_ip_lists << RuntimeSettings::IPList.from_json(ip_list)
-      end
-
       self.monitored_ip_lists = []
-
-      data["monitoredIPAddresses"]&.each do |ip_list|
-        monitored_ip_lists << RuntimeSettings::IPList.from_json(ip_list)
-      end
     end
 
     # Construct a regular expression from the non-nil and non-empty string,

--- a/test/aikido/zen/middleware/ip_list_checker_test.rb
+++ b/test/aikido/zen/middleware/ip_list_checker_test.rb
@@ -4,35 +4,33 @@ require "test_helper"
 
 class Aikido::Zen::Middleware::IPListCheckerTest < ActiveSupport::TestCase
   module Configuration
-    def configure_ips(ip_list_name, ips, key: "key", source: "source", description: "description")
-      if ips.empty?
-        @settings.update_from_runtime_firewall_lists_json({
-          ip_list_name => []
-        })
+    # Core-driven IP list loading is temporarily disabled, so we bypass
+    # update_from_runtime_firewall_lists_json and populate the runtime
+    # settings' lists directly to exercise the middleware.
+    def configure_list(setter, ips, key: "key", source: "source", description: "description")
+      list = if ips.empty?
+        []
       else
-        @settings.update_from_runtime_firewall_lists_json({
-          ip_list_name => [
-            {
-              "key" => key,
-              "source" => source,
-              "description" => description,
-              "ips" => ips
-            }
-          ]
-        })
+        [Aikido::Zen::RuntimeSettings::IPList.from_json({
+          "key" => key,
+          "source" => source,
+          "description" => description,
+          "ips" => ips
+        })]
       end
+      @settings.public_send(setter, list)
     end
 
     def configure_blocked_ips(*args, **kwargs)
-      configure_ips("blockedIPAddresses", *args, **kwargs)
+      configure_list(:blocked_ip_lists=, *args, **kwargs)
     end
 
     def configure_allowed_ips(*args, **kwargs)
-      configure_ips("allowedIPAddresses", *args, **kwargs)
+      configure_list(:allowed_ip_lists=, *args, **kwargs)
     end
 
     def configure_monitored_ips(*args, **kwargs)
-      configure_ips("monitoredIPAddresses", *args, **kwargs)
+      configure_list(:monitored_ip_lists=, *args, **kwargs)
     end
 
     DEFAULT_BLOCKED_IPS = [
@@ -323,10 +321,8 @@ class Aikido::Zen::Middleware::IPListCheckerTest < ActiveSupport::TestCase
         }
       ]
 
-      @settings.update_from_runtime_firewall_lists_json({
-        "blockedIPAddresses" => blocked_ip_lists,
-        "monitoredIPAddresses" => monitored_ip_lists
-      })
+      @settings.blocked_ip_lists = blocked_ip_lists.map { |h| Aikido::Zen::RuntimeSettings::IPList.from_json(h) }
+      @settings.monitored_ip_lists = monitored_ip_lists.map { |h| Aikido::Zen::RuntimeSettings::IPList.from_json(h) }
 
       blocked_ips = [
         "1.4.9.3",

--- a/test/aikido/zen/runtime_settings_test.rb
+++ b/test/aikido/zen/runtime_settings_test.rb
@@ -361,21 +361,10 @@ class Aikido::Zen::RuntimeSettingsTest < ActiveSupport::TestCase
       ]
     })
 
-    assert_kind_of Array, @settings.blocked_ip_lists
-    assert 1, @settings.blocked_ip_lists.size
-    @settings.blocked_ip_lists.each_index do |index|
-      assert_equal "key#{index + 1}", @settings.blocked_ip_lists[index].key
-      assert_equal "source#{index + 1}", @settings.blocked_ip_lists[index].source
-      assert_equal "description#{index + 1}", @settings.blocked_ip_lists[index].description
-    end
-
-    assert_kind_of Array, @settings.allowed_ip_lists
-    assert 2, @settings.allowed_ip_lists.size
-    @settings.allowed_ip_lists.each_index do |index|
-      assert_equal "key#{index + 2}", @settings.allowed_ip_lists[index].key
-      assert_equal "source#{index + 2}", @settings.allowed_ip_lists[index].source
-      assert_equal "description#{index + 2}", @settings.allowed_ip_lists[index].description
-    end
+    # IP list loading is temporarily disabled; all lists stay empty.
+    assert_equal [], @settings.blocked_ip_lists
+    assert_equal [], @settings.allowed_ip_lists
+    assert_equal [], @settings.monitored_ip_lists
 
     assert_kind_of Regexp, @settings.blocked_user_agent_regexp
     assert_kind_of Regexp, @settings.monitored_user_agent_regexp


### PR DESCRIPTION
## Summary
- IP list loading (`blockedIPAddresses`, `allowedIPAddresses`, `monitoredIPAddresses`) in `update_from_runtime_firewall_lists_json` is a no-op for now — the three lists stay empty.
- Reason: `IPListChecker` scans every configured list on every request via `IPSet#include?` (`@ips.any? { |pattern| pattern === ip }`). With realistic core-driven blocklists (tens of thousands of CIDRs across several lists) this produces sustained CPU spikes under load.
- The middleware, API client, heartbeat sync, and all related code stay in place. Only the population step is short-circuited so the middleware branches are cheap (empty lists → early return).
- User-agent blocking/monitoring parsing in the same method is untouched.

## What's NOT done here
- Removing the feature entirely (see the companion revert PR if a full rollback is preferred).
- Redesigning `IPSet` / IP matching for performance. That's the follow-up to re-enable loading.

## Test plan
- [x] `ip_list_checker_test.rb` — test helpers rewired to set `blocked_ip_lists=` / `allowed_ip_lists=` / `monitored_ip_lists=` directly so the middleware behavior is still exercised
- [x] `runtime_settings_test.rb#update_from_runtime_firewall_lists_json from a JSON response` — asserts the three lists stay empty even when payload contains entries
- [ ] CI: full test suite green
- [ ] Manual: confirm CPU usage returns to pre-v1.2.1 levels in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Temporarily disabled populating runtime IP lists to avoid CPU spikes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103678880?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->