### PR TITLE
Prepare 1.2.2

### DIFF
--- a/gemfiles/ruby-2.7.gemfile.lock
+++ b/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.0.gemfile.lock
+++ b/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.1.gemfile.lock
+++ b/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.2.gemfile.lock
+++ b/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.3.gemfile.lock
+++ b/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.4.gemfile.lock
+++ b/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/lib/aikido/zen/version.rb
+++ b/lib/aikido/zen/version.rb
@@ -2,7 +2,7 @@
 
 module Aikido
   module Zen
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
 
     # The version of libzen_internals that we build against.
     LIBZEN_VERSION = "0.1.60"

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.4.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.4.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.4.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.1)
+    aikido-zen (1.2.2)
       concurrent-ruby (~> 1.0)
       ffi
       rack


### PR DESCRIPTION
Bumps `aikido-zen` to v1.2.2.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped Aikido::Zen gem version to 1.2.2 in code


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103687280?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->