### PR TITLE
Fix release.yml and prepare 1.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,4 @@ jobs:
         uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1
         with:
           bundler-cache: true
-      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1
+      - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/gemfiles/ruby-2.7.gemfile.lock
+++ b/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.0.gemfile.lock
+++ b/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.1.gemfile.lock
+++ b/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.2.gemfile.lock
+++ b/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.3.gemfile.lock
+++ b/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/gemfiles/ruby-3.4.gemfile.lock
+++ b/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/lib/aikido/zen/version.rb
+++ b/lib/aikido/zen/version.rb
@@ -2,7 +2,7 @@
 
 module Aikido
   module Zen
-    VERSION = "1.2.2"
+    VERSION = "1.2.3"
 
     # The version of libzen_internals that we build against.
     LIBZEN_VERSION = "0.1.60"

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.4.gemfile.lock
+++ b/sample_apps/rails7.1_path_traversal/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.4.gemfile.lock
+++ b/sample_apps/rails7.1_sql_injection/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-2.7.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-2.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.0.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.1.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.2.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.3.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack

--- a/sample_apps/rails7.1_template/gemfiles/ruby-3.4.gemfile.lock
+++ b/sample_apps/rails7.1_template/gemfiles/ruby-3.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    aikido-zen (1.2.2)
+    aikido-zen (1.2.3)
       concurrent-ruby (~> 1.0)
       ffi
       rack


### PR DESCRIPTION
## Summary

- Bumps `rubygems/release-gem` from v1.0.0 (`a25424ba2ba8b387abc8ef40807c2c85b96cbe32`) to v1.2.0 (`6317d8d1f7e28c24d28f6eff169ea854948bd9f7`) to fix `Unsupported key type PKIX_ED25519` errors from the bundled sigstore-cli when pushing gems with attestation. Fixed upstream in v1.1.2 (sigstore-cli update).
- Bumps `aikido-zen` to v1.2.3 across `lib/aikido/zen/version.rb` and all 24 `*.gemfile.lock` files.

## Why 1.2.3 and not re-release 1.2.2

The v1.2.2 release partially published: 7 of 8 platform gems pushed (fallback path after attestation failure), but `x86_64-mingw-64` and the platform-agnostic `ruby` gem never made it to RubyGems. Per `.github/RELEASE.md` troubleshooting ("bump to X.Y.Z+1 and re-release rather than fighting it"), 1.2.3 is the clean path.

## Test plan

- [ ] CI green (unit tests, lint, e2e)
- [ ] After merge: `gh release create v1.2.3 --target main --title v1.2.3 …` and confirm all 8 platform gems + the ruby gem land on rubygems.org with no `PKIX_ED25519` errors in the workflow log

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped gem VERSION to 1.2.3 preparing new release

**🐛 Bugfixes**
* Updated rubygems/release-gem action to v1.2.0 to fix attestation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103694652?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->