### PR TITLE
Fix SSRF URI matching

### DIFF
--- a/lib/aikido/zen/scanners/ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/ssrf_scanner.rb
@@ -110,17 +110,21 @@ module Aikido::Zen
       private
 
       def match?(conn_uri, input_uri)
-        return false if conn_uri.hostname.nil? || conn_uri.hostname.empty?
+        # If a URI does not include a scheme then hostname and port are nil.
+        # No further comparison is necessary, because the conn_uri hostname
+        # and port are presumed to be non-nil.
         return false if input_uri.hostname.nil? || input_uri.hostname.empty?
 
-        # The URI library will automatically set the port to the default port
-        # for the current scheme if not provided, which means we can't just
-        # check if the port is present, as it always will be.
+        # If a URI does not include a port then port is the default port
+        # for the scheme, otherwise, port is nil. If the input_uri port is
+        # the default port for the scheme then port comparison is skipped,
+        # because the user input is presumed not to have included a port.
         is_port_relevant = input_uri.port != input_uri.default_port
-        return false if is_port_relevant && input_uri.port != conn_uri.port
+        return false if is_port_relevant && conn_uri.port != input_uri.port
 
-        conn_uri.hostname == input_uri.hostname &&
-          conn_uri.port == input_uri.port
+        # The port is either not relevant or is relevant and the conn_uri
+        # port and the input_uri port match. Do not force port comparison!
+        conn_uri.hostname == input_uri.hostname
       end
 
       def private_ip?(hostname)

--- a/test/aikido/zen/scanners/ssrf_scanner_test.rb
+++ b/test/aikido/zen/scanners/ssrf_scanner_test.rb
@@ -66,13 +66,16 @@ class Aikido::Zen::Scanners::SSRFScannerTest < ActiveSupport::TestCase
 
   test "it allows inputs with a port that does not match the connection" do
     refute_attack "http://localhost/", "localhost:8080"
-    refute_attack "http://localhost:8080", "localhost"
   end
 
   test "it detects inputs with ports only if they match the connection's port" do
     assert_attack "http://localhost/", "localhost:80"
     assert_attack "https://localhost/", "localhost:443"
     assert_attack "https://localhost:8080/", "localhost:8080"
+  end
+
+  test "it detects inputs without ports irrespective of the connection's port" do
+    assert_attack "http://localhost:8080/", "localhost"
   end
 
   test "it allows connections if the input has a port but that's not used" do


### PR DESCRIPTION
This change fixes SSRF connection URI and input URI comparison. It includes a detailed comment explaining the invariants. 

This resolves an issue when the input URI did not specify a non-default port for the scheme and makes an internal request to a constructed connection URI that includes the input hostname with a non-matching port; no port-comparison is necessary because port comparison has already been performed if relevant; the port is either not relevant and should not be compared or is relevant and the ports have already been found to match.

This logic error was not original present and was mistakenly introduced in 59206f2e67b41130c415e46c139fc175287f7c1f.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed SSRF connection and input URI comparison logic to match

**📚 Documentation**
* Added detailed comment explaining URI and port comparison invariants


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112368979?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->