### PR TITLE
Improve scanner resilience by continuing scanning payloads

### DIFF
--- a/lib/aikido/zen/scanners/path_traversal_scanner.rb
+++ b/lib/aikido/zen/scanners/path_traversal_scanner.rb
@@ -13,13 +13,14 @@ module Aikido::Zen
       # Path Traversal kind of attacks.
       #
       # @param filepath [String] the expanded path that is tried to be read
-      # @param context [Aikido::Zen::Context]
+      # @param scan [Aikido::Zen::Scan] the running scan.
       # @param sink [Aikido::Zen::Sink] the Sink that is running the scan.
+      # @param context [Aikido::Zen::Context]
       # @param operation [Symbol, String] name of the method being scanned.
       #
       # @return [Aikido::Zen::Attacks::PathTraversalAttack, nil] an Attack if any
       # user input is detected to be attempting a Path Traversal Attack, or +nil+ if not.
-      def self.call(filepath:, sink:, context:, operation:)
+      def self.call(scan:, sink:, context:, filepath:, operation:)
         context.payloads.each do |payload|
           next unless new(filepath, payload.value.to_s).attack?
 
@@ -31,6 +32,8 @@ module Aikido::Zen
             operation: "#{sink.operation}.#{operation}",
             stack: Aikido::Zen.clean_stack_trace
           )
+        rescue => error
+          scan.track_error(error, self)
         end
 
         nil

--- a/lib/aikido/zen/scanners/shell_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/shell_injection_scanner.rb
@@ -10,11 +10,12 @@ module Aikido::Zen
       end
 
       # @param command [String]
+      # @param scan [Aikido::Zen::Scan]
       # @param sink [Aikido::Zen::Sink]
       # @param context [Aikido::Zen::Context]
       # @param operation [Symbol, String]
       #
-      def self.call(command:, sink:, context:, operation:)
+      def self.call(command:, scan:, sink:, context:, operation:)
         context.payloads.each do |payload|
           next unless new(command, payload.value.to_s).attack?
 
@@ -26,6 +27,8 @@ module Aikido::Zen
             operation: "#{sink.operation}.#{operation}",
             stack: Aikido::Zen.clean_stack_trace
           )
+        rescue => error
+          scan.track_error(error, self)
         end
 
         nil

--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -14,18 +14,16 @@ module Aikido::Zen
       # and returns an Attack if so, based on the current request.
       #
       # @param query [String]
-      # @param context [Aikido::Zen::Context]
-      # @param sink [Aikido::Zen::Sink] the Sink that is running the scan.
       # @param dialect [Symbol] one of +:mysql+, +:postgesql+, or +:sqlite+.
+      # @param scan [Aikido::Zen::Scan] the running scan.
+      # @param sink [Aikido::Zen::Sink] the Sink that is running the scan.
+      # @param context [Aikido::Zen::Context]
       # @param operation [Symbol, String] name of the method being scanned.
       #   Expects +sink.operation+ being set to get the full module/name combo.
       #
       # @return [Aikido::Zen::Attack, nil] an Attack if any user input is
       #   detected to be attempting a SQL injection, or nil if this is safe.
-      #
-      # @raise [Aikido::Zen::InternalsError] if an error occurs when loading or
-      #   calling zenlib. See Sink#scan.
-      def self.call(query:, dialect:, sink:, context:, operation:)
+      def self.call(query:, dialect:, scan:, sink:, context:, operation:)
         dialect = DIALECTS.fetch(dialect) do
           Aikido::Zen.config.logger.warn "Unknown SQL dialect #{dialect.inspect}"
           DIALECTS[:common]
@@ -43,6 +41,11 @@ module Aikido::Zen
             operation: "#{sink.operation}.#{operation}",
             stack: Aikido::Zen.clean_stack_trace
           )
+        rescue Aikido::Zen::InternalsError => error
+          Aikido::Zen.config.logger.warn(error.message)
+          scan.track_error(error, self)
+        rescue => error
+          scan.track_error(error, self)
         end
 
         nil

--- a/lib/aikido/zen/scanners/ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/ssrf_scanner.rb
@@ -30,14 +30,15 @@ module Aikido::Zen
       #
       # @param request [Aikido::Zen::Scanners::SSRFScanner::Request, nil]
       #   the ongoing outbound HTTP request.
-      # @param context [Aikido::Zen::Context]
+      # @param scan [Aikido::Zen::Scan] the running scan.
       # @param sink [Aikido::Zen::Sink] the Sink that is running the scan.
+      # @param context [Aikido::Zen::Context]
       # @param operation [Symbol, String] name of the method being scanned.
       #   Expects +sink.operation+ being set to get the full module/name combo.
       #
       # @return [Aikido::Zen::Attacks::SSRFAttack, nil] an Attack if any user
       #   input is detected to be attempting SSRF, or +nil+ if not.
-      def self.call(request:, sink:, context:, operation:, **)
+      def self.call(request:, scan:, sink:, context:, operation:, **)
         return if request.nil? # See NOTE above.
 
         context["ssrf.redirects"] ||= RedirectChains.new
@@ -46,7 +47,7 @@ module Aikido::Zen
           scanner = new(request.uri, payload.value, context["ssrf.redirects"])
           next unless scanner.attack?
 
-          attack = Attacks::SSRFAttack.new(
+          return Attacks::SSRFAttack.new(
             sink: sink,
             request: request,
             input: payload,
@@ -54,8 +55,8 @@ module Aikido::Zen
             operation: "#{sink.operation}.#{operation}",
             stack: Aikido::Zen.clean_stack_trace
           )
-
-          return attack
+        rescue => error
+          scan.track_error(error, self)
         end
 
         nil

--- a/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
@@ -11,7 +11,7 @@ module Aikido::Zen
         false
       end
 
-      def self.call(hostname:, addresses:, operation:, sink:, context:, **opts)
+      def self.call(hostname:, addresses:, operation:, scan:, sink:, context:, **opts)
         offending_address = new(hostname, addresses).attack?
         return if offending_address.nil?
 

--- a/lib/aikido/zen/sink.rb
+++ b/lib/aikido/zen/sink.rb
@@ -94,13 +94,10 @@ module Aikido::Zen
         scanners.each do |scanner|
           next if scanner.skips_on_nil_context? && context.nil?
 
-          result = scanner.call(sink: self, context: context, **scan_params)
+          result = scanner.call(scan: scan, sink: self, context: context, **scan_params)
           scans_performed += 1
 
           break result if result
-        rescue Aikido::Zen::InternalsError => error
-          Aikido::Zen.config.logger.warn(error.message)
-          scan.track_error(error, scanner)
         rescue => error
           scan.track_error(error, scanner)
         end

--- a/test/aikido/zen/scanners/path_traversal_scanner_test.rb
+++ b/test/aikido/zen/scanners/path_traversal_scanner_test.rb
@@ -153,8 +153,11 @@ class Aikido::Zen::Scanners::PathTraversalScannerTest < ActiveSupport::TestCase
         "CONTENT_TYPE" => "application/json"
       })
 
+      scan = Aikido::Zen::Scan.new(sink: nil, context: context)
+
       attack = Aikido::Zen::Scanners::PathTraversalScanner.call(
         filepath: "/app/users/user/../../../etc/passwd",
+        scan: scan,
         sink: stub_sink(name: "test"),
         context: context,
         operation: "test"

--- a/test/aikido/zen/scanners/shell_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/shell_injection_scanner_test.rb
@@ -369,8 +369,11 @@ class Aikido::Zen::Scanners::ShellInjectionScannerTest < ActiveSupport::TestCase
         "CONTENT_TYPE" => "application/json"
       })
 
+      scan = Aikido::Zen::Scan.new(sink: nil, context: context)
+
       attack = Aikido::Zen::Scanners::ShellInjectionScanner.call(
         command: "ls /app/users/user; rm -rf /app/users",
+        scan: scan,
         sink: stub_sink(name: "test"),
         context: context,
         operation: "test"

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -435,9 +435,12 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
         "CONTENT_TYPE" => "application/json"
       })
 
+      scan = Aikido::Zen::Scan.new(sink: nil, context: context)
+
       attack = Aikido::Zen::Scanners::SQLInjectionScanner.call(
         query: "SELECT * FROM users WHERE id=1; DROP TABLE users;",
         dialect: :common,
+        scan: scan,
         sink: stub_sink(name: "test"),
         context: context,
         operation: "test"

--- a/test/aikido/zen/sink_test.rb
+++ b/test/aikido/zen/sink_test.rb
@@ -27,11 +27,13 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
     end
   end
 
+  NOOPScanner = FakeScanner.new { |*args, **kwargs| }
+
   test "provides access to its name and scanners" do
-    sink = Aikido::Zen::Sink.new("test", scanners: [NOOP])
+    sink = Aikido::Zen::Sink.new("test", scanners: [NOOPScanner])
 
     assert_equal "test", sink.name
-    assert_equal [NOOP], sink.scanners
+    assert_equal [NOOPScanner], sink.scanners
   end
 
   test "does not allow initializing without scanners" do
@@ -70,7 +72,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
     Aikido::Zen.current_context = nil
   end
 
-  test "#scan passes the given params to each scanner, plus sink and context" do
+  test "#scan passes the given params to each scanner, plus scan, sink and context" do
     scan_params = nil
     scanner = FakeScanner.new do |**data|
       scan_params = data
@@ -80,7 +82,8 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
     sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
     sink.scan(foo: 1, bar: 2)
 
-    assert_equal({context: nil, foo: 1, bar: 2, sink: sink}, scan_params)
+    assert_hash_subset_of(scan_params, {foo: 1, bar: 2, sink: sink, context: nil})
+    assert_kind_of Aikido::Zen::Scan, scan_params[:scan]
     assert scanner.called?
   end
 
@@ -103,7 +106,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
   end
 
   test "#scan returns a Scan object" do
-    sink = Aikido::Zen::Sink.new("test", scanners: [NOOP])
+    sink = Aikido::Zen::Sink.new("test", scanners: [NOOPScanner])
 
     scan = sink.scan(foo: 1, bar: 2)
 
@@ -179,20 +182,6 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
     assert scanner.called?
   end
 
-  test "#scan logs InternalsErrors besides capturing them" do
-    error = Aikido::Zen::InternalsError.new("<query> for SQLi", "loading", "libzen.so")
-    scanner = FakeScanner.new { raise error }
-    sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
-
-    assert_nothing_raised do
-      scan = sink.scan(foo: 1, bar: 2)
-      assert_includes scan.errors, {error: error, scanner: scanner}
-
-      assert_logged :warn, error.message
-    end
-    assert scanner.called?
-  end
-
   test "#scan tracks how long it takes to run the scanners" do
     scanner = FakeScanner.new { sleep 0.001 and nil }
     sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
@@ -207,11 +196,11 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
 
     test "Sinks.add defines a new sink and registers it" do
       assert_changes -> { Sinks.registry.keys }, from: [], to: ["test"] do
-        sink = Sinks.add("test", scanners: [NOOP])
+        sink = Sinks.add("test", scanners: [NOOPScanner])
 
         assert_kind_of Aikido::Zen::Sink, sink
         assert_equal "test", sink.name
-        assert_equal [NOOP], sink.scanners
+        assert_equal [NOOPScanner], sink.scanners
       end
     end
 
@@ -219,15 +208,15 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
       package = Aikido::Zen::Package.new("test", Gem::Version.new("1.0.0"))
       refute package.supported?
 
-      Sinks.add(package.name, scanners: [NOOP])
+      Sinks.add(package.name, scanners: [NOOPScanner])
       assert package.supported?
     end
 
     test "registering a sink more than once raises an error" do
-      Sinks.add("test", scanners: [NOOP])
+      Sinks.add("test", scanners: [NOOPScanner])
 
       assert_raises ArgumentError do
-        Sinks.add("test", scanners: [NOOP])
+        Sinks.add("test", scanners: [NOOPScanner])
       end
     end
   end

--- a/test/aikido/zen/sinks/mysql2_test.rb
+++ b/test/aikido/zen/sinks/mysql2_test.rb
@@ -21,6 +21,7 @@ class Aikido::Zen::Sinks::Mysql2Test < ActiveSupport::TestCase
     mock.expect :call, nil,
       query: String,
       dialect: :mysql,
+      scan: Aikido::Zen::Scan,
       sink: @sink,
       operation: "query",
       context: Aikido::Zen::Context

--- a/test/aikido/zen/sinks/pg_test.rb
+++ b/test/aikido/zen/sinks/pg_test.rb
@@ -22,6 +22,7 @@ class Aikido::Zen::Sinks::PGTest < ActiveSupport::TestCase
     mock.expect :call, nil,
       query: String,
       dialect: :postgresql,
+      scan: Aikido::Zen::Scan,
       sink: @sink,
       operation: for_operation,
       context: Aikido::Zen::Context

--- a/test/aikido/zen/sinks/sqlite3_test.rb
+++ b/test/aikido/zen/sinks/sqlite3_test.rb
@@ -16,6 +16,7 @@ class Aikido::Zen::Sinks::SQLite3Test < ActiveSupport::TestCase
     mock.expect :call, nil,
       query: String,
       dialect: :sqlite,
+      scan: Aikido::Zen::Scan,
       sink: @sink,
       operation: for_operation,
       context: Aikido::Zen::Context

--- a/test/aikido/zen/sinks/trilogy_test.rb
+++ b/test/aikido/zen/sinks/trilogy_test.rb
@@ -21,6 +21,7 @@ class Aikido::Zen::Sinks::TrilogyTest < ActiveSupport::TestCase
     mock.expect :call, nil,
       query: String,
       dialect: :mysql,
+      scan: Aikido::Zen::Scan,
       sink: @sink,
       operation: "query",
       context: Aikido::Zen::Context


### PR DESCRIPTION
This change improves scanning resilience by ensuring that properly implemented scanners continue scanning with the next payload if an error occurs while scanning the current payload. The `Aikido::Zen::Scan` is now passed to the scanner `call` class method so that scanners can track errors when continuing. Scanners should not raise errors, however, the scan loop continues to rescue errors so that unexpected errors are tracked. Rescuing `Aikido::Zen::InternalsErrors` is now localized to `Aikido::Zen::Scanners::SQLInjectionScanner` because this is the only scanner class that currently uses `zen-internals`.

This change addresses known issues, and preempts future issues, caused by scanners stopping scanning at the first error.

Further refactoring is possible and may be considered in the future: the scan contains the sink and context that passed to the scanner `call` class method; instances of scanner classes would provide more flexibility, for resolving issues cleanly, i.e. scan state is currently externalized and shared by all scanners because scanners are classes and cannot store scan state, forcing shared scan to be injected where scan state is desirable.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 4 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed sink scanning loop to pass Scan and continue on errors

**🔧 Refactors**
* Updated scanners to accept scan parameter and handle per-payload errors
* Localized rescue of Aikido::Zen::InternalsError to SQLInjectionScanner to log


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110404948?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->