### PR TITLE
Test resilient scanning

### DIFF
--- a/test/e2e/rails7.2_generic/app/controllers/api/base_controller.rb
+++ b/test/e2e/rails7.2_generic/app/controllers/api/base_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class BaseController < ApplicationController
+    skip_forgery_protection
+    before_action :set_json_format
+
+    rescue_from StandardError do |error|
+      render json: {
+        error: error.class.name,
+        message: error.message,
+        cause: error.cause
+      }, status: :internal_server_error
+    end
+
+    private
+
+    def set_json_format
+      request.format = :json
+    end
+  end
+end

--- a/test/e2e/rails7.2_generic/app/controllers/api/v1/profiles_controller.rb
+++ b/test/e2e/rails7.2_generic/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class ProfilesController < BaseController
+      include ActionController::Cookies
+
+      def show
+        token = cookies[:token]
+        return render json: {error: "No token cookie"}, status: :unauthorized unless token
+
+        results = ActiveRecord::Base.connection.exec_query(
+          "SELECT name, secret FROM users WHERE token = '#{token}'"
+        )
+        render json: results.rows
+      end
+    end
+  end
+end

--- a/test/e2e/rails7.2_generic/app/models/user.rb
+++ b/test/e2e/rails7.2_generic/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/test/e2e/rails7.2_generic/config/routes.rb
+++ b/test/e2e/rails7.2_generic/config/routes.rb
@@ -11,4 +11,12 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+
+  Rails.application.routes.draw do
+    namespace :api do
+      namespace :v1 do
+        resource :profile, only: [:show]
+      end
+    end
+  end
 end

--- a/test/e2e/rails7.2_generic/db/migrate/20260430102406_create_users.rb
+++ b/test/e2e/rails7.2_generic/db/migrate/20260430102406_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :token
+      t.string :secret
+
+      t.timestamps
+    end
+  end
+end

--- a/test/e2e/rails7.2_generic/db/schema.rb
+++ b/test/e2e/rails7.2_generic/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2026_04_30_102406) do
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "token"
+    t.string "secret"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/test/e2e/rails7.2_generic/db/seeds.rb
+++ b/test/e2e/rails7.2_generic/db/seeds.rb
@@ -7,3 +7,9 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+User.create!([
+  {name: "Alice", token: "abc123", secret: "public_info"},
+  {name: "Bob", token: "def456", secret: "public_info"},
+  {name: "Admin", token: "supersecret", secret: "ADMIN_KEY_12345"}
+])

--- a/test/e2e/rails7.2_generic/test/fixtures/users.yml
+++ b/test/e2e/rails7.2_generic/test/fixtures/users.yml
@@ -1,0 +1,1 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/e2e/rails7.2_generic/test/integration/profiles_test.rb
+++ b/test/e2e/rails7.2_generic/test/integration/profiles_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "json"
+
+class ProfilesTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.load_seed
+  end
+
+  test "request is unauthorized without token cookie" do
+    get "/api/v1/profile"
+
+    assert_response :unauthorized
+
+    assert_response_body_json({
+      "error" => "No token cookie"
+    })
+  end
+
+  test "request is authorized with token cookie" do
+    cookies[:token] = "abc123"
+
+    get "/api/v1/profile"
+
+    assert_response :success
+
+    assert_response_body_json([
+      ["Alice", "public_info"]
+    ])
+  end
+
+  test "detects SQL injection in cookie" do
+    cookies[:token] = "caf%C3%A9' OR 1=1--"
+
+    get "/api/v1/profile"
+
+    assert_response :internal_server_error
+
+    assert_blocked_sql_injection
+  end
+
+  test "detects SQL injection in cookie with poison header" do
+    cookies[:token] = "caf%C3%A9' OR 1=1--"
+
+    get "/api/v1/profile", headers: {"X-Poison" => "\xFF\xFF"}
+
+    assert_response :internal_server_error
+
+    assert_blocked_sql_injection
+  end
+
+  private
+
+  def assert_response_body_json(expected)
+    assert_equal expected, JSON.parse(response.body)
+  end
+
+  def assert_blocked_sql_injection
+    assert_response_body_json({
+      "error" => "ActiveRecord::StatementInvalid",
+      "message" => "Aikido::Zen::SQLInjectionError: Aikido::Zen::SQLInjectionError",
+      "cause" => "Aikido::Zen::SQLInjectionError"
+    })
+  end
+end

--- a/test/e2e/rails7.2_generic/test/models/user_test.rb
+++ b/test/e2e/rails7.2_generic/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This change adds Rails integration tests to the `rails7.2_generic` test application to assert that `aikido-zen` detects SQL injection attacks in a cookie and in a cookie with a poison header.

The poison header is an 8-bit ASCII encoded input string that triggers an `Encoding::CompatibilityError` in `String#include?` in `Aikido::Zen::Scanners::SQLInjectionScanner` when `String#include?` is invoked on a UTF-8 encoded query string in an attempt to halt scanning early.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 1 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GitHub Actions workflow to run Rails end-to-end tests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111862401?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->