### PR TITLE
Fix header normalization

### DIFF
--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -64,10 +64,14 @@ module Aikido::Zen
     def normalized_headers
       @normalized_headers ||= env.slice(*BLESSED_CGI_HEADERS)
         .merge(env.select { |key, _| key.start_with?("HTTP_") })
-        .transform_keys { |header|
-          name = header.sub(/^HTTP_/, "").downcase
-          name.split("_").map { |part| part[0].upcase + part[1..] }.join("-")
-        }
+        .transform_keys do |header|
+          header
+            .delete_prefix("HTTP_")
+            .downcase
+            .split("_")
+            .map(&:capitalize)
+            .join("-")
+        end
     end
 
     def as_json

--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -26,7 +26,7 @@ module Aikido::Zen
 
     def __setobj__(delegate) # :nodoc:
       super
-      @route = @normalized_header = nil
+      @route = @normalized_headers = nil
     end
 
     # @return [Aikido::Zen::Route] the framework route being requested.

--- a/test/e2e/rails7.2_generic/test/integration/profiles_test.rb
+++ b/test/e2e/rails7.2_generic/test/integration/profiles_test.rb
@@ -38,10 +38,20 @@ class ProfilesTest < ActionDispatch::IntegrationTest
     assert_blocked_sql_injection
   end
 
-  test "detects SQL injection in cookie with poison header" do
+  test "detects SQL injection in cookie with poison header value triggering encoding compatibility error" do
     cookies[:token] = "caf%C3%A9' OR 1=1--"
 
     get "/api/v1/profile", headers: {"X-Poison" => "\xFF\xFF"}
+
+    assert_response :internal_server_error
+
+    assert_blocked_sql_injection
+  end
+
+  test "detects SQL injection in cookie with poison header name triggering header normalization error" do
+    cookies[:token] = "caf%C3%A9' OR 1=1--"
+
+    get "/api/v1/profile", headers: {"X--Attack" => "1"}
 
     assert_response :internal_server_error
 


### PR DESCRIPTION
This change resolves a `NoMethodError` in `Aikido::Zen::Request#normalized_headers`. When a header name contains consecutive hyphens, `part` is `""` and `part[0]` returns `nil`; `nil` does not respond to `upcase`:

> undefined method `upcase' for nil (NoMethodError)

The Rails integration test added to the `rails7.2_generic` application asserts that `aikido-zen` detects SQL injection in a cookie with a poison header name containing consecutive hyphens in an attempt to halt scanning early.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed header normalization to avoid NoMethodError on empty parts
* Fixed cached instance variable name when delegate was replaced


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112361533?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->