### PR TITLE
Disable by default block_invalid_sql

### DIFF
--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -28,6 +28,14 @@ module Aikido::Zen
     attr_accessor :blocking_mode
     alias_method :blocking_mode?, :blocking_mode
 
+    # @return [Boolean] is the agent in debugging mode?
+    attr_accessor :debugging
+    alias_method :debugging?, :debugging
+
+    # @return [String] the token obtained when configuring the Firewall in the
+    #   Aikido interface.
+    attr_accessor :api_token
+
     # @return [URI] The HTTP host for the Aikido API. Defaults to
     #   +https://guard.aikido.dev+.
     attr_reader :api_endpoint
@@ -38,10 +46,6 @@ module Aikido::Zen
 
     # @return [Hash] HTTP timeouts for communicating with the API.
     attr_reader :api_timeouts
-
-    # @return [String] the token obtained when configuring the Firewall in the
-    #   Aikido interface.
-    attr_accessor :api_token
 
     # @return [Integer] the interval in seconds to poll the runtime API for
     #   settings changes. Defaults to evey 60 seconds.
@@ -66,10 +70,6 @@ module Aikido::Zen
     # By default, the socket file is created in the current working directory.
     # Defaults to `aikido-detached-agent.sock`.
     attr_accessor :detached_agent_socket_path
-
-    # @return [Boolean] is the agent in debugging mode?
-    attr_accessor :debugging
-    alias_method :debugging?, :debugging
 
     # @return [String] environment specific HTTP header providing the client IP.
     attr_accessor :client_ip_header
@@ -203,15 +203,15 @@ module Aikido::Zen
       self.insert_middleware_after = ::ActionDispatch::RemoteIp
       self.disabled = read_boolean_from_env(ENV.fetch("AIKIDO_DISABLE", false)) || read_boolean_from_env(ENV.fetch("AIKIDO_DISABLED", false))
       self.blocking_mode = read_boolean_from_env(ENV.fetch("AIKIDO_BLOCK", false))
-      self.api_timeouts = 10
+      self.debugging = read_boolean_from_env(ENV.fetch("AIKIDO_DEBUG", false))
+      self.api_token = ENV.fetch("AIKIDO_TOKEN", nil)
       self.api_endpoint = ENV.fetch("AIKIDO_ENDPOINT", DEFAULT_AIKIDO_ENDPOINT)
       self.realtime_endpoint = ENV.fetch("AIKIDO_REALTIME_ENDPOINT", DEFAULT_RUNTIME_BASE_URL)
-      self.api_token = ENV.fetch("AIKIDO_TOKEN", nil)
+      self.api_timeouts = 10
       self.polling_interval = 60 # 1 min
       self.initial_heartbeat_delays = [30, 60 * 2] # 30 sec, 2 min
       self.json_encoder = DEFAULT_JSON_ENCODER
       self.json_decoder = DEFAULT_JSON_DECODER
-      self.debugging = read_boolean_from_env(ENV.fetch("AIKIDO_DEBUG", false))
       self.logger = Logger.new($stdout, progname: "aikido", level: debugging ? Logger::DEBUG : Logger::INFO)
       self.detached_agent_socket_path = ENV.fetch("AIKIDO_DETACHED_AGENT_SOCKET_PATH", DEFAULT_DETACHED_AGENT_SOCKET_PATH)
       self.client_ip_header = ENV.fetch("AIKIDO_CLIENT_IP_HEADER", nil)
@@ -219,17 +219,17 @@ module Aikido::Zen
       self.max_compressed_stats = 100
       self.max_outbound_connections = 200
       self.max_users_tracked = 1000
-      self.request_builder = Aikido::Zen::Context::RACK_REQUEST_BUILDER
       self.blocked_responder = DEFAULT_BLOCKED_RESPONDER
       self.rate_limited_responder = DEFAULT_RATE_LIMITED_RESPONDER
       self.rate_limiting_discriminator = DEFAULT_RATE_LIMITING_DISCRIMINATOR
-      self.server_rate_limit_deadline = 30 * 60 # 30 min
-      self.client_rate_limit_period = 60 * 60 # 1 hour
-      self.client_rate_limit_max_events = 100
       self.collect_api_schema = read_boolean_from_env(ENV.fetch("AIKIDO_FEATURE_COLLECT_API_SCHEMA", true))
       self.api_schema_max_samples = Integer(ENV.fetch("AIKIDO_MAX_API_DISCOVERY_SAMPLES", 10))
       self.api_schema_collection_max_depth = 20
       self.api_schema_collection_max_properties = 20
+      self.request_builder = Aikido::Zen::Context::RACK_REQUEST_BUILDER
+      self.client_rate_limit_period = 60 * 60 # 1 hour
+      self.client_rate_limit_max_events = 100
+      self.server_rate_limit_deadline = 30 * 60 # 30 min
       self.stored_ssrf = read_boolean_from_env(ENV.fetch("AIKIDO_FEATURE_STORED_SSRF", true))
       self.imds_allowed_hosts = ["metadata.google.internal", "metadata.goog"]
       self.harden = read_boolean_from_env(ENV.fetch("AIKIDO_HARDEN", true))

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -166,7 +166,7 @@ module Aikido::Zen
     alias_method :harden?, :harden
 
     # @return [Boolean] whether Aikido Zen should block SQL queries that fail
-    #   tokenization when user input is present. Defaults to true. Can be set
+    #   tokenization when user input is present. Defaults to false. Can be set
     #   through AIKIDO_BLOCK_INVALID_SQL environment variable.
     attr_accessor :block_invalid_sql
     alias_method :block_invalid_sql?, :block_invalid_sql
@@ -233,7 +233,7 @@ module Aikido::Zen
       self.stored_ssrf = read_boolean_from_env(ENV.fetch("AIKIDO_FEATURE_STORED_SSRF", true))
       self.imds_allowed_hosts = ["metadata.google.internal", "metadata.goog"]
       self.harden = read_boolean_from_env(ENV.fetch("AIKIDO_HARDEN", true))
-      self.block_invalid_sql = read_boolean_from_env(ENV.fetch("AIKIDO_BLOCK_INVALID_SQL", true))
+      self.block_invalid_sql = read_boolean_from_env(ENV.fetch("AIKIDO_BLOCK_INVALID_SQL", false))
       self.attack_wave_threshold = 15
       self.attack_wave_min_time_between_requests = 60 * 1000 # 1 min (ms)
       self.attack_wave_min_time_between_events = 20 * 60 * 1000 # 20 min (ms)

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -8,36 +8,47 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
   end
 
   test "default values" do
+    assert_equal ::ActionDispatch::RemoteIp, @config.insert_middleware_after
     assert_equal false, @config.disabled
     assert_equal false, @config.blocking_mode
+    assert_equal false, @config.debugging
     assert_nil @config.api_token
     assert_equal URI("https://guard.aikido.dev"), @config.api_endpoint
     assert_equal URI("https://runtime.aikido.dev"), @config.realtime_endpoint
     assert_equal 10, @config.api_timeouts[:open_timeout]
     assert_equal 10, @config.api_timeouts[:read_timeout]
     assert_equal 10, @config.api_timeouts[:write_timeout]
+    assert_equal 60, @config.polling_interval
+    assert_equal [30, 120], @config.initial_heartbeat_delays
+    assert_equal Aikido::Zen::Config::DEFAULT_JSON_ENCODER, @config.json_encoder
+    assert_equal Aikido::Zen::Config::DEFAULT_JSON_DECODER, @config.json_decoder
     assert_kind_of ::Logger, @config.logger
-    refute @config.debugging
-    assert_equal "aikido-detached-agent.%h.sock", @config.detached_agent_socket_path
+    assert_equal Aikido::Zen::Config::DEFAULT_DETACHED_AGENT_SOCKET_PATH, @config.detached_agent_socket_path
     assert_nil @config.client_ip_header
     assert_equal 5000, @config.max_performance_samples
     assert_equal 100, @config.max_compressed_stats
     assert_equal 200, @config.max_outbound_connections
     assert_equal 1000, @config.max_users_tracked
-    assert_equal [30, 60 * 2], @config.initial_heartbeat_delays
-    assert_equal 60, @config.polling_interval
-    assert_kind_of Proc, @config.blocked_responder
-    assert_kind_of Proc, @config.rate_limited_responder
-    assert_kind_of Proc, @config.rate_limiting_discriminator
+    assert_equal Aikido::Zen::Config::DEFAULT_BLOCKED_RESPONDER, @config.blocked_responder
+    assert_equal Aikido::Zen::Config::DEFAULT_RATE_LIMITED_RESPONDER, @config.rate_limited_responder
+    assert_equal Aikido::Zen::Config::DEFAULT_RATE_LIMITING_DISCRIMINATOR, @config.rate_limiting_discriminator
+    assert_equal true, @config.collect_api_schema?
+    assert_equal 10, @config.api_schema_max_samples
+    assert_equal 20, @config.api_schema_collection_max_depth
+    assert_equal 20, @config.api_schema_collection_max_properties
+    assert_equal Aikido::Zen::Context::RACK_REQUEST_BUILDER, @config.request_builder
     assert_equal 3600, @config.client_rate_limit_period
     assert_equal 100, @config.client_rate_limit_max_events
     assert_equal 1800, @config.server_rate_limit_deadline
-    assert_equal true, @config.collect_api_schema?
-    assert_equal 20, @config.api_schema_collection_max_depth
-    assert_equal 20, @config.api_schema_collection_max_properties
     assert_equal true, @config.stored_ssrf?
     assert_equal ["metadata.google.internal", "metadata.goog"], @config.imds_allowed_hosts
+    assert_equal true, @config.harden
     assert_equal false, @config.block_invalid_sql
+    assert_equal 15, @config.attack_wave_threshold
+    assert_equal 60_000, @config.attack_wave_min_time_between_requests
+    assert_equal 1_200_000, @config.attack_wave_min_time_between_events
+    assert_equal 10_000, @config.attack_wave_max_cache_entries
+    assert_equal 15, @config.attack_wave_max_cache_samples
     assert_equal 1.0, @config.redos_regexp_timeout
   end
 

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -37,6 +37,7 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 20, @config.api_schema_collection_max_properties
     assert_equal true, @config.stored_ssrf?
     assert_equal ["metadata.google.internal", "metadata.goog"], @config.imds_allowed_hosts
+    assert_equal false, @config.block_invalid_sql
     assert_equal 1.0, @config.redos_regexp_timeout
   end
 


### PR DESCRIPTION
This change follows #261. It changes the default configuration option value for `block_invalid_sql` to `false`; disabling the feature by default. This default value for `block_invalid_sql` is now asserted in the test for configuration option defaults.

The last commit improves the test for configuration option defaults, ensuring that all configuration option defaults are asserted and aligning the definition and assertion order of configuration options. (This is useful for quickly identifying and adding missing configuration option defaults assetions.)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed default value of block_invalid_sql to false.

**🔧 Refactors**
* Normalized order and placement of configuration option declarations.
* Improved configuration default tests to assert all option defaults.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112835929?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->