### PR TITLE
Test detects SQL injection in request body with varying content types

### DIFF
--- a/test/e2e/rails7.2_generic/Gemfile
+++ b/test/e2e/rails7.2_generic/Gemfile
@@ -57,3 +57,5 @@ group :test do
 end
 
 gem "aikido-zen", path: "../../../"
+
+gem "actionpack-xml_parser"

--- a/test/e2e/rails7.2_generic/Gemfile.lock
+++ b/test/e2e/rails7.2_generic/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    aikido-zen (1.3.0)
+    aikido-zen (1.3.1)
       concurrent-ruby (~> 1.0)
       ffi
       rack
@@ -42,6 +42,9 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
+    actionpack-xml_parser (2.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     actiontext (7.2.3.1)
       actionpack (= 7.2.3.1)
       activerecord (= 7.2.3.1)
@@ -343,6 +346,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  actionpack-xml_parser
   aikido-zen!
   bootsnap
   brakeman

--- a/test/e2e/rails7.2_generic/app/controllers/api/v1/profiles_controller.rb
+++ b/test/e2e/rails7.2_generic/app/controllers/api/v1/profiles_controller.rb
@@ -12,6 +12,17 @@ module Api
         )
         render json: results.rows
       end
+
+      def update
+        token = cookies[:token]
+        return render json: {error: "No token cookie"}, status: :unauthorized unless token
+
+        results = ActiveRecord::Base.connection.exec_query(
+          # Trigger SQL injection detection with param value "NEW_SECRET', name='NEW_NAME"
+          "UPDATE users SET secret='NEW_SECRET', name='NEW_NAME' WHERE token='#{token}'"
+        )
+        render json: results.rows
+      end
     end
   end
 end

--- a/test/e2e/rails7.2_generic/config/initializers/zen.rb
+++ b/test/e2e/rails7.2_generic/config/initializers/zen.rb
@@ -1,3 +1,8 @@
 if Rails.application.config.respond_to?(:zen)
-  Rails.application.config.zen.blocking_mode = true
+  zen = Rails.application.config.zen
+  zen.blocking_mode = true
+
+  if Rails.env.test?
+    zen.logger = ActiveSupport::Logger.new(File::NULL)
+  end
 end

--- a/test/e2e/rails7.2_generic/config/routes.rb
+++ b/test/e2e/rails7.2_generic/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   Rails.application.routes.draw do
     namespace :api do
       namespace :v1 do
-        resource :profile, only: [:show]
+        resource :profile, only: [:show, :update]
       end
     end
   end

--- a/test/e2e/rails7.2_generic/test/integration/profiles_test.rb
+++ b/test/e2e/rails7.2_generic/test/integration/profiles_test.rb
@@ -48,14 +48,84 @@ class ProfilesTest < ActionDispatch::IntegrationTest
     assert_blocked_sql_injection
   end
 
-  test "detects SQL injection in cookie with poison header name triggering header normalization error" do
-    cookies[:token] = "caf%C3%A9' OR 1=1--"
+  test "detects SQL injection in body with JSON content type" do
+    cookies[:token] = "supersecret"
 
-    get "/api/v1/profile", headers: {"X--Attack" => "1"}
+    params = {
+      user: {
+        secret: "NEW_SECRET', name='NEW_NAME"
+      }
+    }.to_json
+
+    patch "/api/v1/profile",
+      params: params,
+      headers: {
+        "Content-Type" => "application/json"
+      }
 
     assert_response :internal_server_error
 
     assert_blocked_sql_injection
+  end
+
+  test "detects SQL injection in body with XML content type" do
+    cookies[:token] = "supersecret"
+
+    params = {
+      user: {
+        secret: "NEW_SECRET', name='NEW_NAME"
+      }
+    }.to_xml_root
+
+    patch "/api/v1/profile",
+      params: params,
+      headers: {
+        "Content-Type" => "application/xml"
+      }
+
+    assert_response :internal_server_error
+
+    assert_blocked_sql_injection
+  end
+
+  test "detects SQL injection in body and unhandled content type" do
+    cookies[:token] = "supersecret"
+
+    params = {
+      user: {
+        secret: "NEW_SECRET', name='NEW_NAME"
+      }
+    }.to_yaml
+
+    patch "/api/v1/profile",
+      params: params,
+      headers: {
+        "Content-Type" => "application/yaml"
+      }
+
+    assert_response :success
+  end
+
+  test "detects SQL injection in body with incorrect content type" do
+    cookies[:token] = "supersecret"
+
+    params = {
+      user: {
+        secret: "NEW_SECRET', name='NEW_NAME"
+      }
+    }.to_json
+
+    patch "/api/v1/profile",
+      params: params,
+      headers: {
+        "Content-Type" => "application/xml"
+      }
+
+    assert_response :internal_server_error
+
+    json_body = JSON.parse(response.body)
+
+    assert_equal "ActionDispatch::Http::Parameters::ParseError", json_body["error"]
   end
 
   private

--- a/test/e2e/rails7.2_generic/test/test_helper.rb
+++ b/test/e2e/rails7.2_generic/test/test_helper.rb
@@ -13,3 +13,10 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
   end
 end
+
+class Hash
+  def to_xml_root(options = {})
+    key = keys.first
+    self[key].to_xml(options.merge(root: key))
+  end
+end


### PR DESCRIPTION
This change adds Rails integration tests to the `rails7.2_generic` test application to assert that `aikido-zen` detects SQL injection attacks in request body with varying content types; handled content types `application/json` and `application/xml`, unhandled content type `application/yaml`, and incorrect `application/xml` content type with JSON encoded request body.