### PR TITLE
Trim user input before sending to detectSqlInjection

### DIFF
--- a/lib/aikido/zen/scanners/sql_injection_scanner.rb
+++ b/lib/aikido/zen/scanners/sql_injection_scanner.rb
@@ -54,7 +54,7 @@ module Aikido::Zen
 
       def initialize(query, input, dialect)
         @query = query.downcase
-        @input = input.downcase
+        @input = input.downcase.strip
         @dialect = dialect
       end
 

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -261,9 +261,9 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     refute_attack "SELECT * WHERE id =   123  ", "  123  "
   end
 
-  test "flags invalid whitespace around numbers" do
-    assert_attack "SELECT * WHERE id = \n123\n", "\n123\n"
-    assert_attack "SELECT * WHERE id = \t123\t", "\t123\t"
+  test "ignores leading/trailing whitespace around numbers" do
+    refute_attack "SELECT * WHERE id = \n123\n", "\n123\n"
+    refute_attack "SELECT * WHERE id = \t123\t", "\t123\t"
   end
 
   test "ignores comma-separated list of numbers" do

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -218,6 +218,13 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     assert_attack "SELECT id FROM users WHERE email = '' or 1=1 -- a'", "' OR 1=1 -- a"
   end
 
+  test "detects injection when user input has trailing spaces" do
+    assert_attack(
+      "INSERT INTO pets (name, owner) VALUES ('x', 'dummy'), ('injected', 'hacker'); --', 'owner')",
+      "x', 'dummy'), ('injected', 'hacker'); --    "
+    )
+  end
+
   test "it does not flag VIEW as an attack when it's a substring" do
     query = <<~SQL.chomp
       SELECT views.id AS view_id, view_settings.user_id, view_settings.settings


### PR DESCRIPTION
Strips leading/trailing whitespace from user input before SQL injection detection, matching the fix applied to the Java firewall in AikidoSec/firewall-java#298.

**Problem**: An attacker can pad their payload with trailing whitespace (e.g. `"payload   "`). If the DB driver trims this before execution, the SQL query won't contain the padded input, causing `@query.include?(@input)` to return false (missed detection).

**Fix**: Apply `.downcase.strip` to the user input in the SQLInjectionScanner initializer.

See: https://github.com/AikidoSec/firewall-java/pull/298

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Trimmed user input before SQL injection detection to normalize whitespace


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137898526?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->