### PR TITLE
Count 404 requests with foreign extensions as attack wave scans

### DIFF
--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -21,14 +21,14 @@ module Aikido::Zen
         end
       end
 
-      def attack_wave?(context)
+      def attack_wave?(context, status_code = nil)
         client_ip = context.request.client_ip
 
         return false unless client_ip
 
         return false if @event_times[client_ip]
 
-        return false unless AttackWave::Helpers.web_scanner?(context)
+        return false unless AttackWave::Helpers.web_scanner?(context, status_code)
 
         request_count = @request_counts[client_ip] += 1
 

--- a/lib/aikido/zen/attack_wave/helpers.rb
+++ b/lib/aikido/zen/attack_wave/helpers.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Aikido::Zen
   module AttackWave
     module Helpers
-      def self.web_scanner?(context)
-        return true if suspicious_request?(context)
+      def self.web_scanner?(context, status_code)
+        return true if suspicious_request?(context, status_code)
 
         return true if include_suspicious_payload?(context)
 
         false
       end
 
-      def self.suspicious_request?(context)
+      def self.suspicious_request?(context, status_code)
         request = context.request
 
-        suspicious_method?(request.request_method) || suspicious_path?(request.path_info)
+        suspicious_method?(request.request_method) || suspicious_path?(request.path_info, status_code)
       end
 
       def self.suspicious_method?(method)
         SUSPICIOUS_METHODS.include?(method.downcase)
       end
 
-      def self.suspicious_path?(path)
+      def self.suspicious_path?(path, status_code)
         path_parts = path.downcase.split("/")
 
         file_name = path_parts.pop if path_parts.length > 0
@@ -34,6 +36,8 @@ module Aikido::Zen
           file_extension = file_name_parts.pop if file_name_parts.length > 1
 
           return true if SUSPICIOUS_FILE_EXTENSIONS.include?(file_extension)
+
+          return true if FOREIGN_EXTENSIONS.include?(file_extension) && status_code == 404
         end
 
         path_parts.any? do |directory_name|
@@ -433,6 +437,11 @@ module Aikido::Zen
         "sqlitedb",
         "sqlite3db"
       ].map(&:downcase).freeze
+
+      # Extensions that a Ruby app would not natively serve. Requests to these
+      # paths are only treated as scan hits when the response is 404 — a 200
+      # may indicate the app is proxying to a PHP/Java backend.
+      FOREIGN_EXTENSIONS = Set.new(%w[php php3 php4 php5 phtml java jsp jspx]).freeze
 
       SUSPICIOUS_SQL_KEYWORDS = [
         "SELECT (CASE WHEN",

--- a/lib/aikido/zen/middleware/attack_wave_protector.rb
+++ b/lib/aikido/zen/middleware/attack_wave_protector.rb
@@ -12,28 +12,29 @@ module Aikido
 
         def call(env)
           response = @app.call(env)
+          status_code = response[0].to_i
 
           context = @zen.current_context
-          protect(context)
+          protect(context, status_code)
 
           response
         end
 
         # @api private
         # Visible for testing.
-        def attack_wave?(context)
+        def attack_wave?(context, status_code = nil)
           request = context.request
           return false if request.nil?
 
           return false if @settings.bypassed_ips.include?(request.client_ip)
 
-          @zen.attack_wave_detector.attack_wave?(context)
+          @zen.attack_wave_detector.attack_wave?(context, status_code)
         end
 
         # @api private
         # Visible for testing.
-        def protect(context)
-          if attack_wave?(context)
+        def protect(context, status_code = nil)
+          if attack_wave?(context, status_code)
             client_ip = context.request.client_ip
 
             request = Aikido::Zen::AttackWave::Request.new(

--- a/test/aikido/zen/attack_wave_test.rb
+++ b/test/aikido/zen/attack_wave_test.rb
@@ -3,6 +3,38 @@
 require "test_helper"
 
 class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
+  class HelpersTest < ActiveSupport::TestCase
+    test "suspicious_path? returns true for foreign extension with 404 status" do
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/admin.php", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/app.jsp", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/page.jspx", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/index.php3", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/index.php4", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/index.php5", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/index.phtml", 404)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/Hello.java", 404)
+    end
+
+    test "suspicious_path? returns false for foreign extension with non-404 status" do
+      refute Aikido::Zen::AttackWave::Helpers.suspicious_path?("/admin.php", 200)
+      refute Aikido::Zen::AttackWave::Helpers.suspicious_path?("/app.jsp", 200)
+      refute Aikido::Zen::AttackWave::Helpers.suspicious_path?("/admin.php", 301)
+      refute Aikido::Zen::AttackWave::Helpers.suspicious_path?("/admin.php", 500)
+      refute Aikido::Zen::AttackWave::Helpers.suspicious_path?("/admin.php", nil)
+    end
+
+    test "suspicious_path? still returns true for always-suspicious extensions regardless of status" do
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/backup.sql", 200)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/data.db", 200)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/dump.bak", 200)
+    end
+
+    test "suspicious_path? still returns true for suspicious file names regardless of status" do
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/.gitconfig", 200)
+      assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/wp-config.php", 200)
+    end
+  end
+
   class TestClock
     attr_reader :at
 


### PR DESCRIPTION
## Summary

- Ports AikidoSec/firewall-node#1041 to Ruby
- Requests to foreign-platform extensions (`php`, `php3`, `php4`, `php5`, `phtml`, `java`, `jsp`, `jspx`) are only counted as scan hits when the HTTP response status is 404
- A 200 response may mean the Ruby app is proxying to a PHP/Java backend, so those requests should not be flagged as scanning behaviour

## Changes

- **`lib/aikido/zen/attack_wave/helpers.rb`**: Added `FOREIGN_EXTENSIONS` set; updated `suspicious_path?` and `web_scanner?` to accept and use `status_code`
- **`lib/aikido/zen/attack_wave.rb`**: Updated `Detector#attack_wave?` to accept and forward `status_code`
- **`lib/aikido/zen/middleware/attack_wave_protector.rb`**: Extracts `status_code` from the Rack response and passes it through `protect` → `attack_wave?` → detector
- **`test/aikido/zen/attack_wave_test.rb`**: Added `HelpersTest` covering the 404-only and always-suspicious behaviours

## Test plan

- [ ] `suspicious_path?("/admin.php", 404)` → true
- [ ] `suspicious_path?("/admin.php", 200)` → false
- [ ] `suspicious_path?("/app.jsp", 404)` → true
- [ ] Always-suspicious extensions (`.sql`, `.db`, `.bak`) still return true regardless of status
- [ ] Suspicious file names (e.g. `wp-config.php`) still return true regardless of status
- [ ] Run `bundle exec rake test` and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Flagged foreign-extension requests as scans only when response status was 404


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137942819?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->