### PR TITLE
Trim trailing dot from trusted IMDS hostnames

### DIFF
--- a/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
+++ b/lib/aikido/zen/scanners/stored_ssrf_scanner.rb
@@ -36,7 +36,7 @@ module Aikido::Zen
       def attack?
         return unless @config.stored_ssrf? # Feature flag
 
-        return if @config.imds_allowed_hosts.include?(@hostname)
+        return if @config.imds_allowed_hosts.include?(@hostname.chomp("."))
 
         @addresses.find do |address|
           DANGEROUS_ADDRESSES.any? do |dangerous_address|

--- a/test/aikido/zen/scanners/stored_ssrf_scanner_test.rb
+++ b/test/aikido/zen/scanners/stored_ssrf_scanner_test.rb
@@ -32,6 +32,8 @@ class Aikido::Zen::Scanners::StoredSSRFScannerTest < ActiveSupport::TestCase
   test "allows known hosts that resolve to dangerous addresses" do
     refute_attack "metadata.google.internal", ["169.254.169.254"]
     refute_attack "metadata.goog", ["169.254.169.254"]
+    refute_attack "metadata.google.internal.", ["169.254.169.254"]
+    refute_attack "metadata.goog.", ["169.254.169.254"]
   end
 
   test "allows hostnames that are trying to access the IMDS service when the stored SSRF scanning is disabled" do


### PR DESCRIPTION
## Summary

DNS resolvers sometimes return fully-qualified domain names with a trailing dot (e.g. `metadata.google.internal.`). The previous `include?` check in `StoredSSRFScanner#attack?` did not match this form, so GCP IMDS requests could be incorrectly flagged as stored SSRF.

- Use `chomp(".")` to strip a trailing dot before the allowed-host lookup
- Add test cases for trailing-dot variants

This is the same fix already applied in firewall-go (PR #459). Ported to Python, Ruby, .NET, PHP, and Java.

## Test plan
- [ ] `bundle exec rake test` passes

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Trimmed trailing dot from hostname before trusted-host lookup


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137936789?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->