### PR TITLE
Block home-relative paths

### DIFF
--- a/lib/aikido/zen/scanners/path_traversal_scanner.rb
+++ b/lib/aikido/zen/scanners/path_traversal_scanner.rb
@@ -45,6 +45,9 @@ module Aikido::Zen
       end
 
       def attack?
+        # We block home-relative path
+        return true if @filepath.start_with?("~") && @filepath.include?(@input)
+
         # Single character are ignored because they don't pose a big threat
         return false if @input.length <= 1
 

--- a/lib/aikido/zen/scanners/path_traversal_scanner.rb
+++ b/lib/aikido/zen/scanners/path_traversal_scanner.rb
@@ -46,7 +46,7 @@ module Aikido::Zen
 
       def attack?
         # We block home-relative path
-        return true if @filepath.start_with?("~") && @filepath.include?(@input)
+        return true if @input.start_with?("~") && @filepath.start_with?(@input)
 
         # Single character are ignored because they don't pose a big threat
         return false if @input.length <= 1

--- a/test/aikido/zen/scanners/path_traversal_scanner_test.rb
+++ b/test/aikido/zen/scanners/path_traversal_scanner_test.rb
@@ -76,12 +76,55 @@ class Aikido::Zen::Scanners::PathTraversalScannerTest < ActiveSupport::TestCase
     assert_attack "/./etc/passwd", "/./etc/passwd"
     assert_attack "/./././root/file.txt", "/./././root/"
     assert_attack "/./././root/file.txt", "/./././root/file.txt"
+  end
 
+  test "tilde expansion" do
     # File.expand_path expands relative paths that start with ~ to absolute path,
     # which may start with unsafe paths.
+
     assert_attack "~", "~"
     assert_attack "~/", "~/"
     assert_attack "~/file.txt", "~/file.txt"
+
+    assert_attack "~root", "~root"
+    assert_attack "~root/", "~root/"
+    assert_attack "~root/file.txt", "~root/file.txt"
+
+    # File.expand_path will not expand ~ within absolute paths.
+
+    refute_attack "/some-path/~", "~"
+    refute_attack "/some-path/~/", "~/"
+    refute_attack "/some-path/~/file.txt", "~/file.txt"
+
+    refute_attack "/some-path/~root", "~root"
+    refute_attack "/some-path/~root/", "~root/"
+    refute_attack "/some-path/~root/file.txt", "~root/file.txt"
+
+    refute_attack "/some-path/~/some-file", "~"
+    refute_attack "/some-path/~//some-file", "~/"
+    refute_attack "/some-path/~/file.txt/some-file", "~/file.txt"
+
+    refute_attack "/some-path/~root/some-file", "~root"
+    refute_attack "/some-path/~root//some-file", "~root/"
+    refute_attack "/some-path/~root/file.txt/some-file", "~root/file.txt"
+
+    # File.expand_path will not expand ~ in relative paths.
+
+    refute_attack "./~", "~"
+    refute_attack "./~/", "~/"
+    refute_attack "./~/file.txt", "~/file.txt"
+
+    refute_attack "./~root", "~root"
+    refute_attack "./~root/", "~root/"
+    refute_attack "./~root/file.txt", "~root/file.txt"
+
+    refute_attack "./~/some-file", "~"
+    refute_attack "./~//some-file", "~/"
+    refute_attack "./~/file.txt/some-file", "~/file.txt"
+
+    refute_attack "./~root/some-file", "~root"
+    refute_attack "./~root//some-file", "~root/"
+    refute_attack "./~root/file.txt/some-file", "~root/file.txt"
   end
 
   test "does not detect if user input path contains no filename or subfolder" do

--- a/test/aikido/zen/scanners/path_traversal_scanner_test.rb
+++ b/test/aikido/zen/scanners/path_traversal_scanner_test.rb
@@ -76,6 +76,12 @@ class Aikido::Zen::Scanners::PathTraversalScannerTest < ActiveSupport::TestCase
     assert_attack "/./etc/passwd", "/./etc/passwd"
     assert_attack "/./././root/file.txt", "/./././root/"
     assert_attack "/./././root/file.txt", "/./././root/file.txt"
+
+    # File.expand_path expands relative paths that start with ~ to absolute path,
+    # which may start with unsafe paths.
+    assert_attack "~", "~"
+    assert_attack "~/", "~/"
+    assert_attack "~/file.txt", "~/file.txt"
   end
 
   test "does not detect if user input path contains no filename or subfolder" do


### PR DESCRIPTION
`File.expand_path` performs tilde expansion of home-relative paths after the paths are scanned to prevent path traversal attacks into absolute paths that may start with dangerous path starts. This change blocks paths that begin with tilde when the user input is contained in the file path presented for scanning, and so blocks home-relative paths.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Blocked home-relative (~) paths and tightened path traversal predicate


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137868510?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->