### PR TITLE
Exclude Ruby 3.0 from benchmark GitHub workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,8 @@ jobs:
         exclude:
         - ruby: "2.7"
           app: "rails7.1_benchmark"
+        - ruby: "3.0"
+          app: "rails7.1_benchmark"
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/sample_apps/${{ matrix.app }}/Gemfile


### PR DESCRIPTION
Ruby 3.0 has known performance regressions, which we are not currently able to address and cause the benchmark GitHub workflow to fail regularly. This change removes Ruby 3.0 from the benchmark GitHub workflow.

Precedent for this change exists in that Ruby 2.7 is excluded from the benchmark GitHub workflow. It is hoped that these can be reenabled in the future.

See https://github.com/AikidoSec/firewall-ruby/pull/112 and https://github.com/AikidoSec/firewall-ruby/pull/242 for previous attempts to address the failing benchmark GitHub workflow.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Excluded Ruby 3.0 from benchmark GitHub Actions workflow


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137865793?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->