### PR TITLE
Remove realtime settings updates endpoint

### DIFF
--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -80,16 +80,8 @@ module Aikido::Zen
       end
 
       if @config.realtime_settings_updates_enabled?
-        if @api_stream.can_connect?
-          @api_stream.handle("config-updated") { |event| settings_updated(event) }
-          @api_stream.start!
-
-          # Use the realtime setting updates endpoint when polling to check
-          # whether settings should be fetched.
-          @api_client.should_fetch_settings_endpoint = @config.realtime_settings_updates_endpoint
-        else
-          @config.logger.warn("Can't reach #{Aikido::Zen.config.realtime_settings_updates_endpoint}, make sure it's in your outbound firewall allowlist. Realtime config updates won't be available, switched to polling.")
-        end
+        @api_stream.handle("config-updated") { |event| settings_updated(event) }
+        @api_stream.start!
       end
 
       poll_for_setting_updates

--- a/lib/aikido/zen/api_stream.rb
+++ b/lib/aikido/zen/api_stream.rb
@@ -27,7 +27,7 @@ module Aikido::Zen
       @thread = nil
       @http = nil
 
-      endpoint = @config.realtime_settings_updates_endpoint
+      endpoint = @config.realtime_endpoint
 
       @host = endpoint.host
       @port = endpoint.port
@@ -35,31 +35,6 @@ module Aikido::Zen
       @token = @config.api_token
 
       @handlers = Concurrent::Array.new
-    end
-
-    # @return [Boolean] whether we could connect to the realtime endpoint
-    def can_connect?
-      http = Net::HTTP.new(@host, @port)
-      http.use_ssl = @use_ssl
-      http.open_timeout = 5
-      http.write_timeout = 5
-      http.read_timeout = 5
-      http.max_retries = 0
-
-      request = Net::HTTP::Get.new("/config")
-      request["Authorization"] = @token
-
-      begin
-        http.request(request)
-
-        return true
-      rescue Timeout::Error, SocketError, IOError, SystemCallError, OpenSSL::OpenSSLError => err
-        @config.logger.debug("Error probing realtime endpoint: #{err.class}: #{err.message}")
-      rescue => err
-        @config.logger.error("Error probing realtime endpoint: #{err.class}: #{err.message}")
-      end
-
-      false
     end
 
     def running?

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -221,10 +221,6 @@ module Aikido::Zen
     attr_accessor :realtime_settings_updates_enabled
     alias_method :realtime_settings_updates_enabled?, :realtime_settings_updates_enabled
 
-    # @return [URI] The HTTP host for realtime settings updates.
-    #  Defaults to +https://zen.aikido.dev+.
-    attr_reader :realtime_settings_updates_endpoint
-
     def initialize
       self.insert_middleware_after = ::ActionDispatch::RemoteIp
       self.disabled = read_boolean_from_env(ENV.fetch("AIKIDO_DISABLE", false)) || read_boolean_from_env(ENV.fetch("AIKIDO_DISABLED", false))
@@ -271,7 +267,6 @@ module Aikido::Zen
       self.idor_excluded_table_names = []
       self.idor_max_cache_entries = 1000
       self.realtime_settings_updates_enabled = false
-      self.realtime_settings_updates_endpoint = ENV.fetch("AIKIDO_REALTIME_SETTINGS_UPDATES_ENDPOINT", DEFAULT_REALTIME_SETTINGS_UPDATES_BASE_URL)
     end
 
     # Set the base URL for API requests.
@@ -286,13 +281,6 @@ module Aikido::Zen
     # @param url [String, URI]
     def realtime_endpoint=(url)
       @realtime_endpoint = URI(url)
-    end
-
-    # Set the base URL for the realtime settings updates feature.
-    #
-    # @param url [String, URI]
-    def realtime_settings_updates_endpoint=(url)
-      @realtime_settings_updates_endpoint = URI(url)
     end
 
     # Set the logger and configure its severity level according to agent's debug mode
@@ -363,9 +351,6 @@ module Aikido::Zen
 
     # @!visibility private
     DEFAULT_RUNTIME_BASE_URL = "https://runtime.aikido.dev"
-
-    # @!visibility private
-    DEFAULT_REALTIME_SETTINGS_UPDATES_BASE_URL = "https://zen.aikido.dev"
 
     # @!visibility private
     DEFAULT_JSON_ENCODER = JSON.method(:dump)

--- a/test/aikido/zen/agent_test.rb
+++ b/test/aikido/zen/agent_test.rb
@@ -29,10 +29,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     end
   end
 
-  def stub_probe_realtime_endpoint
-    stub_request(:get, "#{@config.realtime_settings_updates_endpoint}/config")
-  end
-
   setup do
     @config = Aikido::Zen.config
     @config.api_token = "TOKEN"
@@ -59,8 +55,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "knows if it has started" do
-    stub_probe_realtime_endpoint
-
     refute @agent.started?
 
     @agent.start!
@@ -71,8 +65,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! fails if attempted to start multiple times" do
-    stub_probe_realtime_endpoint
-
     @agent.start!
 
     err = assert_raises Aikido::ZenError do
@@ -83,16 +75,12 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! sets the start time for our stats funnel" do
-    stub_probe_realtime_endpoint
-
     assert_changes "@collector.stats.started_at", from: nil do
       @agent.start!
     end
   end
 
   test "#start! warns if blocking mode is disabled" do
-    stub_probe_realtime_endpoint
-
     @config.blocking_mode = false
     @agent.start!
 
@@ -101,8 +89,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! notifies if blocking mode is enabled" do
-    stub_probe_realtime_endpoint
-
     @config.blocking_mode = true
     @agent.start!
 
@@ -111,8 +97,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! notifies if an API token has been set" do
-    stub_probe_realtime_endpoint
-
     @config.api_token = "TOKEN"
     @agent.start!
 
@@ -121,8 +105,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! warns if there's no API token set" do
-    stub_probe_realtime_endpoint
-
     @config.api_token = nil
     @agent.start!
 
@@ -130,79 +112,7 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     refute_logged :debug, /api token set! reporting has been enabled/i
   end
 
-  test "#start! probes the realtime endpoint" do
-    request = stub_probe_realtime_endpoint
-      .to_return(status: 200, body: "")
-
-    @config.api_token = "TOKEN"
-    @agent.start!
-
-    assert_requested request
-
-    refute_logged :debug, /error probing realtime endpoint/i
-    refute_logged :error, /error probing realtime endpoint/i
-    refute_logged :warn, /can't reach #{Aikido::Zen.config.realtime_settings_updates_endpoint}/i
-  end
-
-  test "#start! probes the realtime endpoint and logs warning after open timeout" do
-    request = stub_probe_realtime_endpoint
-      .to_raise(Net::OpenTimeout)
-
-    @config.api_token = "TOKEN"
-    @agent.start!
-
-    assert_requested request
-
-    assert_logged :debug, /error probing realtime endpoint/i
-    refute_logged :error, /error probing realtime endpoint/i
-    assert_logged :warn, /can't reach #{Aikido::Zen.config.realtime_settings_updates_endpoint}/i
-  end
-
-  test "#start! probes the realtime endpoint and logs warning after write timeout" do
-    request = stub_probe_realtime_endpoint
-      .to_raise(Net::WriteTimeout)
-
-    @config.api_token = "TOKEN"
-    @agent.start!
-
-    assert_requested request
-
-    assert_logged :debug, /error probing realtime endpoint/i
-    refute_logged :error, /error probing realtime endpoint/i
-    assert_logged :warn, /can't reach #{Aikido::Zen.config.realtime_settings_updates_endpoint}/i
-  end
-
-  test "#start! probes the realtime endpoint and logs warning after read timeout" do
-    request = stub_probe_realtime_endpoint
-      .to_raise(Net::ReadTimeout)
-
-    @config.api_token = "TOKEN"
-    @agent.start!
-
-    assert_requested request
-
-    assert_logged :debug, /error probing realtime endpoint/i
-    refute_logged :error, /error probing realtime endpoint/i
-    assert_logged :warn, /can't reach #{Aikido::Zen.config.realtime_settings_updates_endpoint}/i
-  end
-
-  test "#start! probes the realtime endpoint and logs error after unexpected error" do
-    request = stub_probe_realtime_endpoint
-      .to_raise(RuntimeError)
-
-    @config.api_token = "TOKEN"
-    @agent.start!
-
-    assert_requested request
-
-    refute_logged :debug, /error probing realtime endpoint/i
-    assert_logged :error, /error probing realtime endpoint/i
-    assert_logged :warn, /can't reach #{Aikido::Zen.config.realtime_settings_updates_endpoint}/i
-  end
-
   test "#start! reports a STARTED event" do
-    stub_probe_realtime_endpoint
-
     @api_client.expect :report, {}, [Aikido::Zen::Events::Started]
 
     @agent.start!
@@ -211,8 +121,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! takes the response of the STARTED event as runtime settings" do
-    stub_probe_realtime_endpoint
-
     @api_client.expect :report,
       {"configUpdatedAt" => 1234567890},
       [Aikido::Zen::Events::Started]
@@ -238,8 +146,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! starts polling for setting updates every minute" do
-    stub_probe_realtime_endpoint
-
     @api_client.expect :should_fetch_settings?, false
 
     assert_difference "@worker.jobs.size", +1 do
@@ -255,8 +161,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! updates the runtime settings after polling if needed" do
-    stub_probe_realtime_endpoint
-
     @api_client.expect :should_fetch_settings?, true
     @api_client.expect :fetch_runtime_config, {"configUpdatedAt" => 1234567890}
 
@@ -437,8 +341,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! queues a one-off tasks for each initial heartbeat delay" do
-    stub_probe_realtime_endpoint
-
     size = @config.initial_heartbeat_delays.size
 
     assert_difference "@worker.delayed.size", size do
@@ -454,8 +356,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
   end
 
   test "#start! successfully sends the initial heartbeats" do
-    stub_probe_realtime_endpoint
-
     # Make sure there are _some_ stats
     @collector.track_request
 

--- a/test/aikido/zen/api_stream_test.rb
+++ b/test/aikido/zen/api_stream_test.rb
@@ -8,7 +8,7 @@ class Aikido::Zen::StreamTest < ActiveSupport::TestCase
     config = Aikido::Zen.config
     config.api_token = "TOKEN"
 
-    @endpoint = "#{config.realtime_settings_updates_endpoint}/api/runtime/stream"
+    @endpoint = "#{config.realtime_endpoint}/api/runtime/stream"
 
     @api_stream = Aikido::Zen::APIStream.new(
       min_backoff: 0.02,

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -55,7 +55,6 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal [], @config.idor_excluded_table_names
     assert_equal 1000, @config.idor_max_cache_entries
     assert_equal false, @config.realtime_settings_updates_enabled?
-    assert_equal URI("https://zen.aikido.dev"), @config.realtime_settings_updates_endpoint
   end
 
   test "can set AIKIDO_DISABLE to configure if the agent should be turned off" do


### PR DESCRIPTION
This change removes the `Aikido::Zen.config.realtime_settings_updates_endpoint` and the associated probing machinery, used to probe whether the realtime settings updates endpoint is accessible and use it for polling.

This is in preparation for an ongoing simplification of endpoints used by Zen by Aikido and should not be merged until the unified realtime endpoint supports realtime settings updates, otherwise this will not work, even if the feature flag is enabled.

See #285 for more information about realtime software updates.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Removed realtime settings updates endpoint configuration and probe
* Simplified agent startup to always enable API stream without probing
* Replaced APIStream probing with direct use of realtime endpoint


<sup>[More info](https://app.aikido.dev/featurebranch/scan/139778979?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->