### PR TITLE
Add data regions support

### DIFF
--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -37,7 +37,8 @@ module Aikido::Zen
     attr_accessor :api_token
 
     # @return [URI] The HTTP host for the Aikido API. Defaults to
-    #   +https://guard.aikido.dev+.
+    #   +https://guard.aikido.dev+, or a region-specific host derived from
+    #   the +api_token+ (e.g. +https://guard.us.aikido.dev+).
     attr_reader :api_endpoint
 
     # @return [URI] The HTTP host for the Aikido Runtime API. Defaults to
@@ -230,7 +231,7 @@ module Aikido::Zen
       self.blocking_mode = read_boolean_from_env(ENV.fetch("AIKIDO_BLOCK", false))
       self.debugging = read_boolean_from_env(ENV.fetch("AIKIDO_DEBUG", false))
       self.api_token = ENV.fetch("AIKIDO_TOKEN", nil)
-      self.api_endpoint = ENV.fetch("AIKIDO_ENDPOINT", DEFAULT_AIKIDO_ENDPOINT)
+      self.api_endpoint = ENV.fetch("AIKIDO_ENDPOINT") { regional_api_endpoint(api_token) }
       self.realtime_endpoint = ENV.fetch("AIKIDO_REALTIME_ENDPOINT", DEFAULT_RUNTIME_BASE_URL)
       self.api_timeouts = 10
       self.polling_interval = 60 # 1 min
@@ -321,6 +322,32 @@ module Aikido::Zen
 
     private
 
+    # Extracts the region from an Aikido runtime token, if present.
+    #
+    # Tokens can either be in the old format (without a region) or the new
+    # format (with a region):
+    #   old: AIK_RUNTIME_{sys_group_id}_{service_id}_{random}
+    #   new: AIK_RUNTIME_{sys_group_id}_{service_id}_{region}_{random}
+    #
+    # @param token [String, nil]
+    # @return [String] the region code (e.g. "US"), or "EU" if the token does
+    #   not encode a region.
+    def extract_region_from_token(token)
+      return "EU" unless token&.start_with?(TOKEN_PREFIX)
+
+      parts = token.delete_prefix(TOKEN_PREFIX).split("_")
+      return parts[2] if parts.length == 4
+
+      "EU"
+    end
+
+    # @param token [String, nil]
+    # @return [String] the base URL for the Aikido API for the region
+    #   encoded in the given token, defaulting to the EU endpoint.
+    def regional_api_endpoint(token)
+      REGIONAL_AIKIDO_ENDPOINTS.fetch(extract_region_from_token(token), DEFAULT_AIKIDO_ENDPOINT)
+    end
+
     def read_boolean_from_env(value)
       return value unless value.respond_to?(:to_str)
 
@@ -334,6 +361,16 @@ module Aikido::Zen
 
     # @!visibility private
     DEFAULT_AIKIDO_ENDPOINT = "https://guard.aikido.dev"
+
+    # @!visibility private
+    TOKEN_PREFIX = "AIK_RUNTIME_"
+
+    # @!visibility private
+    REGIONAL_AIKIDO_ENDPOINTS = {
+      "US" => "https://guard.us.aikido.dev",
+      "ME" => "https://guard.me.aikido.dev",
+      "AU" => "https://guard.au.aikido.dev"
+    }.freeze
 
     # @!visibility private
     DEFAULT_RUNTIME_BASE_URL = "https://runtime.aikido.dev"

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -149,6 +149,45 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     end
   end
 
+  test "derives the api_endpoint region from the AIKIDO_TOKEN" do
+    {
+      "US" => "https://guard.us.aikido.dev",
+      "ME" => "https://guard.me.aikido.dev",
+      "AU" => "https://guard.au.aikido.dev"
+    }.each do |region, expected_endpoint|
+      with_env "AIKIDO_TOKEN" => "AIK_RUNTIME_1_2_#{region}_random" do
+        config = Aikido::Zen::Config.new
+        assert_equal URI(expected_endpoint), config.api_endpoint
+      end
+    end
+  end
+
+  test "defaults to the EU api_endpoint for tokens without a region" do
+    with_env "AIKIDO_TOKEN" => "AIK_RUNTIME_1_2_random" do
+      config = Aikido::Zen::Config.new
+      assert_equal URI("https://guard.aikido.dev"), config.api_endpoint
+    end
+  end
+
+  test "defaults to the EU api_endpoint for tokens with an unknown region" do
+    with_env "AIKIDO_TOKEN" => "AIK_RUNTIME_1_2_ZZ_random" do
+      config = Aikido::Zen::Config.new
+      assert_equal URI("https://guard.aikido.dev"), config.api_endpoint
+    end
+  end
+
+  test "defaults to the EU api_endpoint when there is no token" do
+    config = Aikido::Zen::Config.new
+    assert_equal URI("https://guard.aikido.dev"), config.api_endpoint
+  end
+
+  test "AIKIDO_ENDPOINT takes precedence over the region derived from the token" do
+    with_env "AIKIDO_TOKEN" => "AIK_RUNTIME_1_2_US_random", "AIKIDO_ENDPOINT" => "https://test.aikido.dev" do
+      config = Aikido::Zen::Config.new
+      assert_equal URI("https://test.aikido.dev"), config.api_endpoint
+    end
+  end
+
   test "can set blocking_mode via an ENV variable" do
     assert_boolean_env_var "AIKIDO_BLOCK" do |config|
       config.blocking_mode


### PR DESCRIPTION
Manually tested with rails7.1_sql_injection sample app and EU / US data region

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added data regions support deriving region-specific API endpoints from tokens


<sup>[More info](https://app.aikido.dev/featurebranch/scan/148438334?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->