### PR TITLE
Skip extracting payloads with non-string values

### DIFF
--- a/lib/aikido/zen/context.rb
+++ b/lib/aikido/zen/context.rb
@@ -98,7 +98,9 @@ module Aikido::Zen
 
     # @!visibility private
     def extract_payloads_from(data, source_type, prefix = nil)
-      if data.respond_to?(:to_hash)
+      if data.is_a?(String)
+        [Payload.new(data, source_type, prefix.to_s)]
+      elsif data.respond_to?(:to_hash)
         data.to_hash.flat_map do |key, value|
           extract_payloads_from(value, source_type, [prefix, key].compact.join("."))
         end
@@ -125,7 +127,7 @@ module Aikido::Zen
 
         payloads
       else
-        [Payload.new(data, source_type, prefix.to_s)]
+        []
       end
     end
 

--- a/test/aikido/zen/context_test.rb
+++ b/test/aikido/zen/context_test.rb
@@ -209,15 +209,24 @@ class Aikido::Zen::ContextTest < ActiveSupport::TestCase
     test "body payloads are read from JSON-encoded bodies" do
       context = build_context_for("/example", {
         :method => "POST",
-        :input => %({"test":"value","nested":{"hash":"data"},"array":[1, 2, 3]}),
+        :input => %({"key":"value","hash":{"first":0,"key":"value","last":2.0},"array":["1", "two", 3, "iv"]}),
         "CONTENT_TYPE" => "application/json"
       })
 
-      assert_includes context.payloads, stub_payload(:body, "value", "test")
-      assert_includes context.payloads, stub_payload(:body, "data", "nested.hash")
-      assert_includes context.payloads, stub_payload(:body, 1, "array.0")
-      assert_includes context.payloads, stub_payload(:body, 2, "array.1")
-      assert_includes context.payloads, stub_payload(:body, 3, "array.2")
+      assert_includes context.payloads, stub_payload(:body, "value", "key")
+
+      assert_includes context.payloads, stub_payload(:body, "value", "hash.key")
+
+      # Values must be strings to be extracted
+      refute_includes context.payloads, stub_payload(:body, 0, "hash.first")
+      refute_includes context.payloads, stub_payload(:body, 2.0, "hash.last")
+
+      assert_includes context.payloads, stub_payload(:body, "1", "array.0")
+      assert_includes context.payloads, stub_payload(:body, "two", "array.1")
+      assert_includes context.payloads, stub_payload(:body, "iv", "array.3")
+
+      # Values must be strings to be extracted
+      refute_includes context.payloads, stub_payload(:body, 3, "array.3")
     end
 
     test "body payloads are not read from JSON-encoded bodies that cannot be parsed" do


### PR DESCRIPTION
This change skips extracting payloads with non-string values, which can lead to `NoMethodError`s when the payload value is assumed to be a `String`.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Handled String payloads explicitly when extracting payloads from data

**🐛 Bugfixes**
* Skipped extracting payloads with non-string values to prevent NoMethodError


<sup>[More info](https://app.aikido.dev/featurebranch/scan/144407914?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->