### PR TITLE
Dampen missing custom IP header log output to debug level

### DIFF
--- a/lib/aikido/zen/request.rb
+++ b/lib/aikido/zen/request.rb
@@ -51,10 +51,15 @@ module Aikido::Zen
 
       if @config.client_ip_header
         value = env[@config.client_ip_header]
-        if Resolv::AddressRegex.match?(value)
-          @client_ip = value
+
+        if value
+          if Resolv::AddressRegex.match?(value)
+            @client_ip = value
+          else
+            @config.logger.warn("Invalid IP address in custom client IP header `#{@config.client_ip_header}`: `#{value}`")
+          end
         else
-          @config.logger.warn("Invalid IP address in custom client IP header `#{@config.client_ip_header}`: `#{value}`")
+          @config.logger.debug("Custom client IP header `#{@config.client_ip_header}` not present in request")
         end
       end
 

--- a/test/aikido/zen/request_test.rb
+++ b/test/aikido/zen/request_test.rb
@@ -62,17 +62,6 @@ class Aikido::Zen::RequestTest < ActiveSupport::TestCase
       assert_equal "1.2.3.4", req.as_json["ipAddress"]
     end
 
-    test "#as_json includes the remote IP from the custom client IP header" do
-      Aikido::Zen.config.client_ip_header = "HTTP_CUSTOM_CLIENT_IP"
-
-      env = Rack::MockRequest.env_for("/test", "REMOTE_ADDR" => "1.2.3.4", "HTTP_CUSTOM_CLIENT_IP" => "4.3.2.1")
-      req = build_request(env)
-
-      assert_equal "4.3.2.1", req.as_json["ipAddress"]
-
-      Aikido::Zen.config.client_ip_header = nil
-    end
-
     test "#as_json includes the User-Agent" do
       env = Rack::MockRequest.env_for("/test", "HTTP_USER_AGENT" => "Some/UA")
       req = build_request(env)
@@ -85,6 +74,54 @@ class Aikido::Zen::RequestTest < ActiveSupport::TestCase
       req = build_request(env)
 
       assert_equal req.framework, req.as_json["source"]
+    end
+
+    test "#as_json includes the remote IP from the custom client IP header" do
+      Aikido::Zen.config.client_ip_header = "HTTP_CUSTOM_CLIENT_IP"
+
+      env = Rack::MockRequest.env_for("/test", "REMOTE_ADDR" => "1.2.3.4", "HTTP_CUSTOM_CLIENT_IP" => "4.3.2.1")
+      req = build_request(env)
+
+      assert_equal "4.3.2.1", req.as_json["ipAddress"]
+
+      Aikido::Zen.config.client_ip_header = nil
+    end
+
+    test "#client_ip logs a warning when the custom client IP header is present but invalid" do
+      Aikido::Zen.config.client_ip_header = "HTTP_CUSTOM_CLIENT_IP"
+
+      env = Rack::MockRequest.env_for("/test", "REMOTE_ADDR" => "1.2.3.4", "HTTP_CUSTOM_CLIENT_IP" => "not-an-ip")
+      req = build_request(env)
+
+      assert_equal "1.2.3.4", req.client_ip
+      assert_logged :warn, /Invalid IP address in custom client IP header `HTTP_CUSTOM_CLIENT_IP`: `not-an-ip`/
+
+      Aikido::Zen.config.client_ip_header = nil
+    end
+
+    test "#client_ip logs a warning when the custom client IP header is present but empty" do
+      Aikido::Zen.config.client_ip_header = "HTTP_CUSTOM_CLIENT_IP"
+
+      env = Rack::MockRequest.env_for("/test", "REMOTE_ADDR" => "1.2.3.4", "HTTP_CUSTOM_CLIENT_IP" => "")
+      req = build_request(env)
+
+      assert_equal "1.2.3.4", req.client_ip
+      assert_logged :warn, /Invalid IP address in custom client IP header `HTTP_CUSTOM_CLIENT_IP`/
+
+      Aikido::Zen.config.client_ip_header = nil
+    end
+
+    test "#client_ip logs a debug message when the custom client IP header is not present" do
+      Aikido::Zen.config.client_ip_header = "HTTP_CUSTOM_CLIENT_IP"
+
+      env = Rack::MockRequest.env_for("/test", "REMOTE_ADDR" => "1.2.3.4")
+      req = build_request(env)
+
+      assert_equal "1.2.3.4", req.client_ip
+      assert_logged :debug, /Custom client IP header `HTTP_CUSTOM_CLIENT_IP` not present in request/
+      refute_logged :warn, /client IP header/
+
+      Aikido::Zen.config.client_ip_header = nil
     end
 
     test "#schema builds the request schema" do


### PR DESCRIPTION
This change causes a debug level log message to be outputted when the custom `client_ip_header` is set but not present, to reduce the noise from the generic warn level log message.

This change builds on top of #307 because of merge conflicts. It should be merged after #307.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 5 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Dampened missing custom IP header log to debug level


<sup>[More info](https://app.aikido.dev/featurebranch/scan/148421286?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->