### PR TITLE
Fix Encoding::CompatibilityError in write_coalesced_frame_with_deadline

### DIFF
--- a/lib/aikido/zen/ipc/ipc.rb
+++ b/lib/aikido/zen/ipc/ipc.rb
@@ -174,14 +174,14 @@ module Aikido
         end
 
         def write_frame_with_deadline(socket, data, max_size, deadline)
-          bytes = data.b
+          size = data.bytesize
 
-          if max_size && bytes.bytesize > max_size
-            raise FrameTooLargeError.new(bytes.bytesize, max_size)
+          if max_size && size > max_size
+            raise FrameTooLargeError.new(size, max_size)
           end
 
-          write_with_deadline(socket, [bytes.bytesize].pack("N"), deadline)
-          write_with_deadline(socket, bytes, deadline)
+          write_with_deadline(socket, [size].pack("N"), deadline)
+          write_with_deadline(socket, data, deadline)
         end
 
         def write_frame_with_timeout(socket, data, max_size, timeout)
@@ -191,15 +191,18 @@ module Aikido
         end
 
         def write_coalesced_frame_with_deadline(socket, data, max_size, deadline)
-          bytes = data.b
-          size = bytes.bytesize
+          size = data.bytesize
 
           if max_size && size > max_size
             raise FrameTooLargeError.new(size, max_size)
           end
 
+          # String#<< raises Encoding::CompatibilityError when concatenating
+          # strings with different encodings unless one of them is ASCII-only.
           frame = [size].pack("N")
-          frame << bytes
+          # Retag data to avoid copying it.
+          frame.force_encoding(data.encoding)
+          frame << data
 
           write_with_deadline(socket, frame, deadline)
         end

--- a/lib/aikido/zen/ipc/ipc.rb
+++ b/lib/aikido/zen/ipc/ipc.rb
@@ -191,14 +191,15 @@ module Aikido
         end
 
         def write_coalesced_frame_with_deadline(socket, data, max_size, deadline)
-          size = data.bytesize
+          bytes = data.b
+          size = bytes.bytesize
 
           if max_size && size > max_size
             raise FrameTooLargeError.new(size, max_size)
           end
 
           frame = [size].pack("N")
-          frame << data
+          frame << bytes
 
           write_with_deadline(socket, frame, deadline)
         end

--- a/test/aikido/zen/ipc/ipc_test.rb
+++ b/test/aikido/zen/ipc/ipc_test.rb
@@ -690,6 +690,28 @@ class Aikido::Zen::IPC::FramedIOTest < ActiveSupport::TestCase
   ensure
     writer.close
   end
+
+  test "#write_coalesced_frame_with_timeout handles UTF-8 data whose size prefix contains a high byte" do
+    reader, writer = socket_pair
+
+    # String#<< used to raise Encoding::CompatibilityError when the ASCII-8BIT
+    # size prefix had a byte >= 128 and was concatenated with non-ASCII data.
+    data = ("héllo " * 30).dup.force_encoding(Encoding::UTF_8)
+
+    refute data.ascii_only?
+    assert data.bytesize >= 128
+
+    buffer = String.new(encoding: Encoding::BINARY)
+
+    thread = Thread.new { write_coalesced_frame_with_timeout(writer, data, nil, 5.0) }
+    result = read_coalesced_frame_with_timeout(reader, buffer, nil, 5.0)
+    thread.join
+
+    assert_equal data.b, result
+  ensure
+    reader.close
+    writer.close
+  end
 end
 
 class Aikido::Zen::IPC::HandshakeTest < ActiveSupport::TestCase


### PR DESCRIPTION
This change fixes an `Encoding::CompatibilityError` in `Aikido::Zen::IPC::FramedIO#write_coalesced_frame_with_deadline` when the ASCII-8BIT frame size prefix contains a byte >= 128 and is concatenated with non-ASCII (i.e. UTF-8) string data.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed Encoding::CompatibilityError when ASCII-8BIT size prefix concatenated with UTF-8

**🔧 Refactors**
* Avoided unnecessary binary copy and used bytesize for frame sizing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/148982782?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->