### PR TITLE
Fix realtime settings updates

### DIFF
--- a/lib/aikido/zen/api_stream.rb
+++ b/lib/aikido/zen/api_stream.rb
@@ -116,6 +116,7 @@ module Aikido::Zen
       http.open_timeout = @open_timeout
       http.write_timeout = @write_timeout
       http.read_timeout = @read_timeout
+      # Working around Net::HTTP cleverness; retries GET requests once by default.
       http.max_retries = 0
 
       request = Net::HTTP::Get.new("/api/runtime/stream")

--- a/lib/aikido/zen/api_stream.rb
+++ b/lib/aikido/zen/api_stream.rb
@@ -123,6 +123,9 @@ module Aikido::Zen
       request["Authorization"] = @token
       request["Accept"] = "text/event-stream"
       request["Cache-Control"] = "no-cache"
+      # Working around Net::HTTP cleverness; auto-negotiates gzip and buffers
+      # decompressed output internally.
+      request["Accept-Encoding"] = "identity"
 
       @config.logger.debug("API stream connecting")
       http.start


### PR DESCRIPTION
This change fixes realtime settings updates after an external change, which cased the Zen realtime API to begin honoring auto-negotiated gzip compression. `Net::HTTP`s automatic decompression prevents `Aikido::Zen::APIStream` from receiving data because data is buffered upto a (32 KB) threshold; the read timeout is never triggered because data is read, but that data is not surfaced in `Net::HTTPResponse#read_body`. Setting `Accept-Encoding` prevents `Net::HTTP` from auto-negotiating gzip compression.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Disabled Net::HTTP automatic retries for streaming GET requests.
* Forced identity Accept-Encoding to prevent gzip auto-negotiation buffering.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/151314440?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->