### PR TITLE
Optimize multiprocess runtime settings updates

### DIFF
--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -59,12 +59,20 @@ module Aikido::Zen
         return
       end
 
+      # Code coverage is disabled here because the block is only called when
+      # the process exits.
+      # :nocov:
       at_exit { stop! if started? }
+      # :nocov:
 
       report(Events::Started.new(time: @started_at)) do |response|
         if update_settings_from_runtime_config!(response, reason: "after start")
           updated_settings!
+        # :nocov:
+        else
+          # empty
         end
+        # :nocov:
       rescue => err
         @config.logger.error(err.message)
       end
@@ -173,7 +181,11 @@ module Aikido::Zen
           updated_settings!
 
           update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after heartbeat")
+        # :nocov:
+        else
+          # empty
         end
+        # :nocov:
       end
     end
 
@@ -189,7 +201,11 @@ module Aikido::Zen
         if @api_client.should_fetch_settings?
           if update_settings_from_runtime_config!(@api_client.fetch_runtime_config, reason: "after polling")
             updated_settings!
+          # :nocov:
+          else
+            # empty
           end
+          # :nocov:
 
           update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after polling")
         end
@@ -206,7 +222,11 @@ module Aikido::Zen
           updated_settings!
 
           update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after server-sent event")
+        # :nocov:
+        else
+          # empty
         end
+        # :nocov:
       end
     end
 
@@ -228,13 +248,18 @@ module Aikido::Zen
     # @param reason [String] context appended to the log message when logged
     # @return [Boolean]
     def update_settings_from_runtime_config!(data, reason:)
+      # :nocov:
       return unless @runtime_config_update_mutex.try_lock
+      # :nocov:
       begin
         return false unless Aikido::Zen.api_cache.update_runtime_config(data)
 
-        result = Aikido::Zen.runtime_settings.update_from_runtime_config_json(data)
-        @config.logger.info("Updated runtime settings #{reason}") if result
-        result
+        if Aikido::Zen.runtime_settings.update_from_runtime_config_json(data)
+          @config.logger.info("Updated runtime settings #{reason}")
+          true
+        else
+          false
+        end
       ensure
         @runtime_config_update_mutex.unlock
       end
@@ -244,13 +269,18 @@ module Aikido::Zen
     # @param reason [String] context appended to the log message when logged
     # @return [Boolean]
     def update_settings_from_runtime_firewall_lists!(data, reason:)
+      # :nocov:
       return unless @runtime_firewall_lists_update_mutex.try_lock
+      # :nocov:
       begin
         return false unless Aikido::Zen.api_cache.update_runtime_firewall_lists(data)
 
-        result = Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(data)
-        @config.logger.info("Updated runtime firewall list #{reason}") if result
-        result
+        if Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(data)
+          @config.logger.info("Updated runtime firewall list #{reason}")
+          true
+        else
+          false
+        end
       ensure
         @runtime_firewall_lists_update_mutex.unlock
       end

--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -246,7 +246,8 @@ module Aikido::Zen
 
     # @param data [Hash]
     # @param reason [String] context appended to the log message when logged
-    # @return [Boolean]
+    # @return [Boolean] whether the settings were updated; or nil if another
+    #   thread is already applying an update.
     def update_settings_from_runtime_config!(data, reason:)
       # :nocov:
       return unless @runtime_config_update_mutex.try_lock
@@ -267,7 +268,8 @@ module Aikido::Zen
 
     # @param data [Hash]
     # @param reason [String] context appended to the log message when logged
-    # @return [Boolean]
+    # @return [Boolean] whether the settings were updated; or nil if another
+    #   thread is already applying an update.
     def update_settings_from_runtime_firewall_lists!(data, reason:)
       # :nocov:
       return unless @runtime_firewall_lists_update_mutex.try_lock

--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -62,23 +62,25 @@ module Aikido::Zen
       at_exit { stop! if started? }
 
       report(Events::Started.new(time: @started_at)) do |response|
-        if update_settings_from_runtime_config!(response)
+        if update_settings_from_runtime_config!(response, reason: "after start")
           updated_settings!
-          @config.logger.info("Updated runtime settings")
         end
       rescue => err
         @config.logger.error(err.message)
       end
 
       begin
-        update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists)
-        @config.logger.info("Updated runtime firewall list")
+        update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after start")
       rescue => err
         @config.logger.error(err.message)
       end
 
       if @config.realtime_settings_updates_enabled?
-        @api_stream.handle("config-updated") { |event| settings_updated(event) }
+        @api_stream.handle("config-updated") do |event|
+          @config.logger.debug("Received server-sent event: config-updated")
+          settings_updated(event)
+        end
+
         @api_stream.start!
       end
 
@@ -167,12 +169,10 @@ module Aikido::Zen
 
       heartbeat = @collector.flush
       report(heartbeat) do |response|
-        if update_settings_from_runtime_config!(response)
+        if update_settings_from_runtime_config!(response, reason: "after heartbeat")
           updated_settings!
-          @config.logger.info("Updated runtime settings after heartbeat")
 
-          update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists)
-          @config.logger.info("Updated runtime firewall list after heartbeat")
+          update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after heartbeat")
         end
       end
     end
@@ -187,13 +187,11 @@ module Aikido::Zen
     def poll_for_setting_updates
       @worker.every(@config.polling_interval) do
         if @api_client.should_fetch_settings?
-          if update_settings_from_runtime_config!(@api_client.fetch_runtime_config)
+          if update_settings_from_runtime_config!(@api_client.fetch_runtime_config, reason: "after polling")
             updated_settings!
-            @config.logger.info("Updated runtime settings after polling")
           end
 
-          update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists)
-          @config.logger.info("Updated runtime firewall list after polling")
+          update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after polling")
         end
       end
     end
@@ -204,12 +202,10 @@ module Aikido::Zen
       updated_at = Time.at(event[:data]["configUpdatedAt"].to_i)
 
       if should_fetch_settings?(updated_at)
-        if update_settings_from_runtime_config!(@api_client.fetch_runtime_config)
+        if update_settings_from_runtime_config!(@api_client.fetch_runtime_config, reason: "after server-sent event")
           updated_settings!
-          @config.logger.info("Updated runtime settings after server-sent event")
 
-          update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists)
-          @config.logger.info("Updated runtime firewall list after server-sent event")
+          update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after server-sent event")
         end
       end
     end
@@ -229,26 +225,32 @@ module Aikido::Zen
     end
 
     # @param data [Hash]
+    # @param reason [String] context appended to the log message when logged
     # @return [Boolean]
-    def update_settings_from_runtime_config!(data)
+    def update_settings_from_runtime_config!(data, reason:)
       return unless @runtime_config_update_mutex.try_lock
       begin
         return false unless Aikido::Zen.api_cache.update_runtime_config(data)
 
-        Aikido::Zen.runtime_settings.update_from_runtime_config_json(data)
+        result = Aikido::Zen.runtime_settings.update_from_runtime_config_json(data)
+        @config.logger.info("Updated runtime settings #{reason}") if result
+        result
       ensure
         @runtime_config_update_mutex.unlock
       end
     end
 
     # @param data [Hash]
+    # @param reason [String] context appended to the log message when logged
     # @return [Boolean]
-    def update_settings_from_runtime_firewall_lists!(data)
+    def update_settings_from_runtime_firewall_lists!(data, reason:)
       return unless @runtime_firewall_lists_update_mutex.try_lock
       begin
         return false unless Aikido::Zen.api_cache.update_runtime_firewall_lists(data)
 
-        Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(data)
+        result = Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(data)
+        @config.logger.info("Updated runtime firewall list #{reason}") if result
+        result
       ensure
         @runtime_firewall_lists_update_mutex.unlock
       end

--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -206,10 +206,10 @@ module Aikido::Zen
       if should_fetch_settings?(updated_at)
         if update_settings_from_runtime_config!(@api_client.fetch_runtime_config)
           updated_settings!
-          @config.logger.info("Updated runtime settings after server-side event")
+          @config.logger.info("Updated runtime settings after server-sent event")
 
           update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists)
-          @config.logger.info("Updated runtime firewall list after server-side event")
+          @config.logger.info("Updated runtime firewall list after server-sent event")
         end
       end
     end

--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -233,7 +233,8 @@ module Aikido::Zen
     def update_settings_from_runtime_config!(data)
       return unless @runtime_config_update_mutex.try_lock
       begin
-        Aikido::Zen.api_cache.runtime_config = data
+        return false unless Aikido::Zen.api_cache.update_runtime_config(data)
+
         Aikido::Zen.runtime_settings.update_from_runtime_config_json(data)
       ensure
         @runtime_config_update_mutex.unlock
@@ -245,7 +246,8 @@ module Aikido::Zen
     def update_settings_from_runtime_firewall_lists!(data)
       return unless @runtime_firewall_lists_update_mutex.try_lock
       begin
-        Aikido::Zen.api_cache.runtime_firewall_lists = data
+        return false unless Aikido::Zen.api_cache.update_runtime_firewall_lists(data)
+
         Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(data)
       ensure
         @runtime_firewall_lists_update_mutex.unlock

--- a/lib/aikido/zen/api_cache.rb
+++ b/lib/aikido/zen/api_cache.rb
@@ -23,19 +23,23 @@ module Aikido::Zen
     # @param value [Hash, nil]
     # @return [Boolean] whether the value actually changed
     def update_runtime_config(value)
-      changed = value != @runtime_config
-      @runtime_config_generation += 1 if changed
+      return false if value == @runtime_config
+
+      @runtime_config_generation += 1
       @runtime_config = value
-      changed
+
+      true
     end
 
     # @param value [Hash, nil]
     # @return [Boolean] whether the value actually changed
     def update_runtime_firewall_lists(value)
-      changed = value != @runtime_firewall_lists
-      @runtime_firewall_lists_generation += 1 if changed
+      return false if value == @runtime_firewall_lists
+
+      @runtime_firewall_lists_generation += 1
       @runtime_firewall_lists = value
-      changed
+
+      true
     end
 
     # @param known_generation [Integer, nil]

--- a/lib/aikido/zen/api_cache.rb
+++ b/lib/aikido/zen/api_cache.rb
@@ -2,7 +2,40 @@
 
 module Aikido::Zen
   class APICache
-    attr_accessor :runtime_config
-    attr_accessor :runtime_firewall_lists
+    attr_reader :runtime_config
+    attr_reader :runtime_firewall_lists
+    attr_reader :runtime_config_generation
+    attr_reader :runtime_firewall_lists_generation
+
+    def initialize
+      @runtime_config_generation = 0
+      @runtime_firewall_lists_generation = 0
+    end
+
+    def runtime_config=(value)
+      @runtime_config_generation += 1 unless value == @runtime_config
+      @runtime_config = value
+    end
+
+    def runtime_firewall_lists=(value)
+      @runtime_firewall_lists_generation += 1 unless value == @runtime_firewall_lists
+      @runtime_firewall_lists = value
+    end
+
+    # @param known_generation [Integer, nil]
+    # @return [Array(Object, Integer), nil] the current value and generation,
+    #   or nil if the known generation is already current.
+    def config_if_changed(known_generation)
+      return nil if known_generation == runtime_config_generation
+      [runtime_config, runtime_config_generation]
+    end
+
+    # @param known_generation [Integer, nil]
+    # @return [Array(Object, Integer), nil] the current value and generation,
+    #   or nil if the known generation is already current.
+    def firewall_lists_if_changed(known_generation)
+      return nil if known_generation == runtime_firewall_lists_generation
+      [runtime_firewall_lists, runtime_firewall_lists_generation]
+    end
   end
 end

--- a/lib/aikido/zen/api_cache.rb
+++ b/lib/aikido/zen/api_cache.rb
@@ -13,13 +13,29 @@ module Aikido::Zen
     end
 
     def runtime_config=(value)
-      @runtime_config_generation += 1 unless value == @runtime_config
-      @runtime_config = value
+      update_runtime_config(value)
     end
 
     def runtime_firewall_lists=(value)
-      @runtime_firewall_lists_generation += 1 unless value == @runtime_firewall_lists
+      update_runtime_firewall_lists(value)
+    end
+
+    # @param value [Hash, nil]
+    # @return [Boolean] whether the value actually changed
+    def update_runtime_config(value)
+      changed = value != @runtime_config
+      @runtime_config_generation += 1 if changed
+      @runtime_config = value
+      changed
+    end
+
+    # @param value [Hash, nil]
+    # @return [Boolean] whether the value actually changed
+    def update_runtime_firewall_lists(value)
+      changed = value != @runtime_firewall_lists
+      @runtime_firewall_lists_generation += 1 if changed
       @runtime_firewall_lists = value
+      changed
     end
 
     # @param known_generation [Integer, nil]

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -60,6 +60,10 @@ module Aikido::Zen
     #   poll the parent process for updated runtime settings. Defaults to 10 seconds.
     attr_accessor :worker_process_polling_interval
 
+    # @return [Integer] the maximum random delay in seconds before a forked
+    #   worker process starts polling. Defaults to 10 seconds.
+    attr_accessor :worker_process_polling_jitter
+
     # @return [Integer] the interval in seconds at which forked worker processes
     #   flush their collected stats to the parent process. Defaults to 10 seconds.
     attr_accessor :worker_process_heartbeat_interval
@@ -237,6 +241,7 @@ module Aikido::Zen
       self.polling_interval = 60 # 1 min
       self.initial_heartbeat_delays = [30, 60 * 2] # 30 sec, 2 min
       self.worker_process_polling_interval = 10
+      self.worker_process_polling_jitter = 10
       self.worker_process_heartbeat_interval = 10
       self.json_encoder = DEFAULT_JSON_ENCODER
       self.json_decoder = DEFAULT_JSON_DECODER

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -16,6 +16,7 @@ module Aikido::Zen::WorkerProcess
         worker: Aikido::Zen::Worker.new(config: config),
         keepalive_worker: Aikido::Zen::Worker.new(config: config),
         polling_interval: config.worker_process_polling_interval,
+        polling_jitter: config.worker_process_polling_jitter,
         heartbeat_interval: config.worker_process_heartbeat_interval,
         collector: Aikido::Zen.collector
       )
@@ -23,6 +24,7 @@ module Aikido::Zen::WorkerProcess
         @worker = worker
         @keepalive_worker = keepalive_worker
         @polling_interval = polling_interval
+        @polling_jitter = polling_jitter
         @heartbeat_interval = heartbeat_interval
         @collector = collector
 
@@ -107,6 +109,13 @@ module Aikido::Zen::WorkerProcess
       def schedule_tasks
         @keepalive_worker.every(KEEPALIVE_INTERVAL, run_now: false) { keepalive }
 
+        # Delay start polling to reduce the chance of workers polling in lockstep.
+        @worker.delay(polling_start_delay) { start_polling }
+
+        @worker.every(@heartbeat_interval, run_now: false) { send_collector_events }
+      end
+
+      def start_polling
         @worker.every(@polling_interval, run_now: false) do
           if update_settings(updated_settings)
             @config.logger.debug("Forked worker process #{Process.pid}: updated runtime settings from parent")
@@ -114,8 +123,13 @@ module Aikido::Zen::WorkerProcess
         rescue => err
           @config.logger.error("Forked worker process #{Process.pid}: failed to get settings from parent: #{err.message}")
         end
+      end
 
-        @worker.every(@heartbeat_interval, run_now: false) { send_collector_events }
+      def polling_start_delay
+        return 0 if @polling_jitter < 1
+
+        # Seed by pid because forked processes inherit identical PRNG state.
+        Random.new(Process.pid).rand(1..@polling_jitter)
       end
 
       def keepalive

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -39,14 +39,7 @@ module Aikido::Zen::WorkerProcess
       end
 
       def start
-        @rpc_client.start do
-          @worker.perform do
-            update_settings(updated_settings)
-          rescue => err
-            @config.logger.error("Forked worker process #{Process.pid}: failed to get settings after connecting to parent: #{err.message}")
-          end
-        end
-
+        @rpc_client.start
         schedule_tasks
       end
 
@@ -116,7 +109,7 @@ module Aikido::Zen::WorkerProcess
       end
 
       def start_polling
-        @worker.every(@polling_interval, run_now: false) do
+        @worker.every(@polling_interval, run_now: true) do
           if update_settings(updated_settings)
             @config.logger.debug("Forked worker process #{Process.pid}: updated runtime settings from parent")
           end

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -79,43 +79,49 @@ module Aikido::Zen::WorkerProcess
         )
       end
 
-      def update_settings(settings)
+      def update_settings
+        settings = updated_settings
         return false unless settings
+        return false unless settings["config"] || settings["firewall_lists"]
 
-        updated = false
+        @config.logger.debug("Forked worker process #{Process.pid}: starting runtime settings update")
 
         if settings["config"]
+          @config.logger.debug("Forked worker process #{Process.pid}: starting config update")
           Aikido::Zen.runtime_settings.update_from_runtime_config_json(settings["config"])
           @known_config_generation = settings["config_generation"]
-          updated = true
+          @config.logger.debug("Forked worker process #{Process.pid}: finished config update")
         end
 
         if settings["firewall_lists"]
+          @config.logger.debug("Forked worker process #{Process.pid}: starting firewall_lists update")
           Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(settings["firewall_lists"])
           @known_firewall_lists_generation = settings["firewall_lists_generation"]
-          updated = true
+          @config.logger.debug("Forked worker process #{Process.pid}: finished firewall_lists update")
         end
 
-        updated
+        @config.logger.debug("Forked worker process #{Process.pid}: finished runtime settings update")
+
+        true
+      rescue => err
+        @config.logger.error("Forked worker process #{Process.pid}: failed to get settings from parent: #{err.message}")
+        false
       end
 
       def schedule_tasks
         @keepalive_worker.every(KEEPALIVE_INTERVAL, run_now: false) { keepalive }
 
         # Delay start polling to reduce the chance of workers polling in lockstep.
-        @worker.delay(polling_start_delay) { start_polling }
+        delay = polling_start_delay
+        @config.logger.debug("Forked worker process #{Process.pid}: will start polling in #{delay}s")
+        @worker.delay(delay) { start_polling }
 
         @worker.every(@heartbeat_interval, run_now: false) { send_collector_events }
       end
 
       def start_polling
-        @worker.every(@polling_interval, run_now: true) do
-          if update_settings(updated_settings)
-            @config.logger.debug("Forked worker process #{Process.pid}: updated runtime settings from parent")
-          end
-        rescue => err
-          @config.logger.error("Forked worker process #{Process.pid}: failed to get settings from parent: #{err.message}")
-        end
+        @config.logger.debug("Forked worker process #{Process.pid}: started polling")
+        @worker.every(@polling_interval, run_now: true) { update_settings }
       end
 
       def polling_start_delay

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -27,6 +27,9 @@ module Aikido::Zen::WorkerProcess
         @collector = collector
 
         @rpc_client = Aikido::Zen::RPC::Client.new(secret, host, port, reconnect: true)
+
+        @known_config_generation = nil
+        @known_firewall_lists_generation = nil
       end
 
       def close
@@ -73,28 +76,41 @@ module Aikido::Zen::WorkerProcess
       private
 
       def updated_settings
-        @rpc_client.invoke("updated_settings", KEEPALIVE_INTERVAL)
+        @rpc_client.invoke(
+          "updated_settings",
+          KEEPALIVE_INTERVAL,
+          @known_config_generation,
+          @known_firewall_lists_generation
+        )
       end
 
       def update_settings(settings)
-        return unless settings
+        return false unless settings
+
+        updated = false
 
         if settings["config"]
           Aikido::Zen.runtime_settings.update_from_runtime_config_json(settings["config"])
+          @known_config_generation = settings["config_generation"]
+          updated = true
         end
 
         if settings["firewall_lists"]
           Aikido::Zen.runtime_settings.update_from_runtime_firewall_lists_json(settings["firewall_lists"])
+          @known_firewall_lists_generation = settings["firewall_lists_generation"]
+          updated = true
         end
+
+        updated
       end
 
       def schedule_tasks
         @keepalive_worker.every(KEEPALIVE_INTERVAL, run_now: false) { keepalive }
 
         @worker.every(@polling_interval, run_now: false) do
-          update_settings(updated_settings)
-
-          @config.logger.debug("Forked worker process #{Process.pid}: updated runtime settings from parent")
+          if update_settings(updated_settings)
+            @config.logger.debug("Forked worker process #{Process.pid}: updated runtime settings from parent")
+          end
         rescue => err
           @config.logger.error("Forked worker process #{Process.pid}: failed to get settings from parent: #{err.message}")
         end

--- a/lib/aikido/zen/worker_process/agent/server.rb
+++ b/lib/aikido/zen/worker_process/agent/server.rb
@@ -12,8 +12,8 @@ module Aikido::Zen::WorkerProcess
           respond.call(nil)
         end
 
-        @rpc_server.handle("updated_settings") do |respond|
-          respond.call(updated_settings)
+        @rpc_server.handle("updated_settings") do |respond, known_config_generation = nil, known_firewall_lists_generation = nil|
+          respond.call(updated_settings(known_config_generation, known_firewall_lists_generation))
         end
 
         @rpc_server.handle("send_collector_events") do |respond, events_data|
@@ -64,11 +64,20 @@ module Aikido::Zen::WorkerProcess
       # Visible for testing.
       RequestKind = Struct.new(:route, :schema, :client_ip, :actor)
 
-      def updated_settings
-        {
-          "config" => Aikido::Zen.api_cache.runtime_config,
-          "firewall_lists" => Aikido::Zen.api_cache.runtime_firewall_lists
-        }
+      def updated_settings(known_config_generation = nil, known_firewall_lists_generation = nil)
+        result = {}
+
+        config_change = Aikido::Zen.api_cache.config_if_changed(known_config_generation)
+        if config_change
+          result["config"], result["config_generation"] = config_change
+        end
+
+        firewall_lists_change = Aikido::Zen.api_cache.firewall_lists_if_changed(known_firewall_lists_generation)
+        if firewall_lists_change
+          result["firewall_lists"], result["firewall_lists_generation"] = firewall_lists_change
+        end
+
+        result
       end
 
       def send_collector_events(events_data)

--- a/test/aikido/zen/agent_test.rb
+++ b/test/aikido/zen/agent_test.rb
@@ -477,8 +477,8 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     @agent.send(:settings_updated, {data: {"configUpdatedAt" => 2000}})
 
     assert_mock @api_client
-    assert_logged :info, /updated runtime settings after server-side event/i
-    assert_logged :info, /updated runtime firewall list after server-side event/i
+    assert_logged :info, /updated runtime settings after server-sent event/i
+    assert_logged :info, /updated runtime firewall list after server-sent event/i
   end
 
   test "#settings_updated does not fetch when the timestamp is not newer" do
@@ -486,6 +486,6 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
 
     @agent.send(:settings_updated, {data: {"configUpdatedAt" => 1000}})
 
-    refute_logged :info, /updated runtime settings after server-side event/i
+    refute_logged :info, /updated runtime settings after server-sent event/i
   end
 end

--- a/test/aikido/zen/agent_test.rb
+++ b/test/aikido/zen/agent_test.rb
@@ -37,7 +37,7 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     @collector = Aikido::Zen.collector
     @worker = MockWorker.new
     @api_client = Minitest::Mock.new(MockAPIClient.new)
-    @api_stream = Minitest::Mock.new(MockAPIStream.new)
+    @api_stream = MockAPIStream.new
 
     @agent = Aikido::Zen::Agent.new(
       config: @config,
@@ -52,6 +52,22 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
 
   teardown do
     @agent.stop!
+  end
+
+  test ".start creates a new agent and immediately starts it" do
+    @api_client.expect :should_fetch_settings?, false
+
+    agent = Aikido::Zen::Agent.start(
+      config: @config,
+      collector: @collector,
+      worker: @worker,
+      api_client: @api_client,
+      api_stream: @api_stream
+    )
+
+    assert agent.started?
+  ensure
+    agent.stop!
   end
 
   test "knows if it has started" do
@@ -133,6 +149,16 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     assert_logged :info, /updated runtime settings/i
   end
 
+  test "#start! logs an error if handling the STARTED event response raises" do
+    @api_client.expect :report, {"configUpdatedAt" => 1234567890}, [Aikido::Zen::Events::Started]
+
+    @agent.stub :update_settings_from_runtime_config!, ->(*) { raise "boom" } do
+      assert_nothing_raised { @agent.start! }
+    end
+
+    assert_logged :error, /boom/
+  end
+
   test "#start! does not report a STARTED event if it does not have an API token" do
     @config.api_token = nil
 
@@ -143,6 +169,43 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     assert_nothing_raised do
       @agent.start!
     end
+  end
+
+  test "#start! logs an error if updating firewall lists on startup raises" do
+    @agent.stub :update_settings_from_runtime_firewall_lists!, ->(*) { raise "boom" } do
+      assert_nothing_raised { @agent.start! }
+    end
+
+    assert_logged :error, /boom/
+  end
+
+  test "#start! registers a handler for config-updated events when realtime settings updates are enabled" do
+    Aikido::Zen.runtime_settings.updated_at = Time.at(1000)
+
+    @api_client.expect :fetch_runtime_firewall_lists, {}
+    @api_client.expect :fetch_runtime_config, {"configUpdatedAt" => 2000}
+    @api_client.expect :fetch_runtime_firewall_lists, {}
+
+    @agent.start!
+
+    handlers = @api_stream.instance_variable_get(:@handlers)
+
+    handlers.each do |handler|
+      handler.call(type: "config-updated", data: {"configUpdatedAt" => 2000})
+    end
+
+    assert_logged :debug, /received server-sent event: config-updated/i
+    assert_logged :info, /updated runtime settings after server-sent event/i
+
+    assert_mock @api_client
+  end
+
+  test "#start! does not register any event handlers when realtime settings updates are disabled" do
+    @config.realtime_settings_updates_enabled = false
+
+    @agent.start!
+
+    assert_empty @api_stream.instance_variable_get(:@handlers)
   end
 
   test "#start! starts polling for setting updates every minute" do
@@ -340,6 +403,15 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     assert second_timer.running?
   end
 
+  test "#updated_settings! does not restart heartbeats when they are running and not stale" do
+    Aikido::Zen.runtime_settings.heartbeat_interval = 10
+    @agent.updated_settings!
+
+    assert_no_difference "@worker.jobs.size" do
+      @agent.updated_settings!
+    end
+  end
+
   test "#start! queues a one-off tasks for each initial heartbeat delay" do
     size = @config.initial_heartbeat_delays.size
 
@@ -487,5 +559,59 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     @agent.send(:settings_updated, {data: {"configUpdatedAt" => 1000}})
 
     refute_logged :info, /updated runtime settings after server-sent event/i
+  end
+
+  test "#update_settings_from_runtime_config! updates settings and logs a message including the reason" do
+    config_data = {"configUpdatedAt" => 1234567890}
+
+    assert @agent.send(:update_settings_from_runtime_config!, config_data, reason: "for some reason")
+
+    assert_logged :info, /updated runtime settings for some reason/i
+  end
+
+  test "#update_settings_from_runtime_config! returns false and does not log when settings are unchanged" do
+    config_data = {"configUpdatedAt" => 1234567890}
+    Aikido::Zen.api_cache.update_runtime_config(config_data)
+
+    refute @agent.send(:update_settings_from_runtime_config!, config_data, reason: "for some reason")
+
+    refute_logged :info, /updated runtime settings/i
+  end
+
+  test "#update_settings_from_runtime_config! does not log when the config timestamp is unchanged" do
+    Aikido::Zen.runtime_settings.updated_at = Time.at(1234567890)
+
+    config_data = {"configUpdatedAt" => 1234567890, "blockedUserIds" => ["1"]}
+
+    refute @agent.send(:update_settings_from_runtime_config!, config_data, reason: "for some reason")
+
+    refute_logged :info, /updated runtime settings/i
+  end
+
+  test "#update_settings_from_runtime_firewall_lists! updates settings and logs a message including the reason" do
+    firewall_data = {"blockedIPAddresses" => []}
+
+    assert @agent.send(:update_settings_from_runtime_firewall_lists!, firewall_data, reason: "for some reason")
+
+    assert_logged :info, /updated runtime firewall list for some reason/i
+  end
+
+  test "#update_settings_from_runtime_firewall_lists! returns false and does not log when settings are unchanged" do
+    firewall_data = {"blockedIPAddresses" => []}
+    Aikido::Zen.api_cache.update_runtime_firewall_lists(firewall_data)
+
+    refute @agent.send(:update_settings_from_runtime_firewall_lists!, firewall_data, reason: "for some reason")
+
+    refute_logged :info, /updated runtime firewall list/i
+  end
+
+  test "#update_settings_from_runtime_firewall_lists! does not log when the update did not change any settings" do
+    firewall_data = {"blockedIPAddresses" => []}
+
+    Aikido::Zen.runtime_settings.stub :update_from_runtime_firewall_lists_json, false do
+      refute @agent.send(:update_settings_from_runtime_firewall_lists!, firewall_data, reason: "for some reason")
+    end
+
+    refute_logged :info, /updated runtime firewall list/i
   end
 end

--- a/test/aikido/zen/api_cache_test.rb
+++ b/test/aikido/zen/api_cache_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Aikido::Zen::APICacheTest < ActiveSupport::TestCase
+  def build_cache
+    Aikido::Zen::APICache.new
+  end
+
+  test "runtime_config_generation starts at 0" do
+    assert_equal 0, build_cache.runtime_config_generation
+  end
+
+  test "#runtime_config= increments runtime_config_generation" do
+    cache = build_cache
+    cache.runtime_config = {"configUpdatedAt" => 1}
+
+    assert_equal 1, cache.runtime_config_generation
+  end
+
+  test "#runtime_config= does not increment runtime_config_generation when the value is unchanged" do
+    cache = build_cache
+    cache.runtime_config = {"configUpdatedAt" => 1}
+
+    cache.runtime_config = {"configUpdatedAt" => 1}
+
+    assert_equal 1, cache.runtime_config_generation
+  end
+
+  test "#config_if_changed returns the value and generation when the known generation is nil" do
+    cache = build_cache
+    cache.runtime_config = {"configUpdatedAt" => 1}
+
+    assert_equal [cache.runtime_config, cache.runtime_config_generation], cache.config_if_changed(nil)
+  end
+
+  test "#config_if_changed returns nil when the known generation matches the current one" do
+    cache = build_cache
+    cache.runtime_config = {"configUpdatedAt" => 1}
+
+    assert_nil cache.config_if_changed(cache.runtime_config_generation)
+  end
+
+  test "#config_if_changed returns the value and generation again once it changes" do
+    cache = build_cache
+    cache.runtime_config = {"configUpdatedAt" => 1}
+    stale_generation = cache.runtime_config_generation
+
+    cache.runtime_config = {"configUpdatedAt" => 2}
+
+    assert_equal [{"configUpdatedAt" => 2}, cache.runtime_config_generation], cache.config_if_changed(stale_generation)
+  end
+
+  test "runtime_firewall_lists_generation starts at 0" do
+    assert_equal 0, build_cache.runtime_firewall_lists_generation
+  end
+
+  test "#runtime_firewall_lists= increments runtime_firewall_lists_generation" do
+    cache = build_cache
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    assert_equal 1, cache.runtime_firewall_lists_generation
+  end
+
+  test "#runtime_firewall_lists= does not increment runtime_firewall_lists_generation when the value is unchanged" do
+    cache = build_cache
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    assert_equal 1, cache.runtime_firewall_lists_generation
+  end
+
+  test "#firewall_lists_if_changed returns the value and generation when the known generation is nil" do
+    cache = build_cache
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    assert_equal [cache.runtime_firewall_lists, cache.runtime_firewall_lists_generation],
+      cache.firewall_lists_if_changed(nil)
+  end
+
+  test "#firewall_lists_if_changed returns nil when the known generation matches the current one" do
+    cache = build_cache
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    assert_nil cache.firewall_lists_if_changed(cache.runtime_firewall_lists_generation)
+  end
+
+  test "#firewall_lists_if_changed returns the value and generation again once it changes" do
+    cache = build_cache
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+    stale_generation = cache.runtime_firewall_lists_generation
+
+    cache.runtime_firewall_lists = {"blockedIPAddresses" => ["1.2.3.4"]}
+
+    assert_equal [{"blockedIPAddresses" => ["1.2.3.4"]}, cache.runtime_firewall_lists_generation],
+      cache.firewall_lists_if_changed(stale_generation)
+  end
+end

--- a/test/aikido/zen/api_cache_test.rb
+++ b/test/aikido/zen/api_cache_test.rb
@@ -27,6 +27,26 @@ class Aikido::Zen::APICacheTest < ActiveSupport::TestCase
     assert_equal 1, cache.runtime_config_generation
   end
 
+  test "#update_runtime_config returns true when the value changes" do
+    cache = build_cache
+
+    assert cache.update_runtime_config({"configUpdatedAt" => 1})
+  end
+
+  test "#update_runtime_config returns false when the value is unchanged" do
+    cache = build_cache
+    cache.update_runtime_config({"configUpdatedAt" => 1})
+
+    refute cache.update_runtime_config({"configUpdatedAt" => 1})
+  end
+
+  test "#update_runtime_config returns true again once the value changes" do
+    cache = build_cache
+    cache.update_runtime_config({"configUpdatedAt" => 1})
+
+    assert cache.update_runtime_config({"configUpdatedAt" => 2})
+  end
+
   test "#config_if_changed returns the value and generation when the known generation is nil" do
     cache = build_cache
     cache.runtime_config = {"configUpdatedAt" => 1}
@@ -69,6 +89,26 @@ class Aikido::Zen::APICacheTest < ActiveSupport::TestCase
     cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
 
     assert_equal 1, cache.runtime_firewall_lists_generation
+  end
+
+  test "#update_runtime_firewall_lists returns true when the value changes" do
+    cache = build_cache
+
+    assert cache.update_runtime_firewall_lists({"blockedIPAddresses" => []})
+  end
+
+  test "#update_runtime_firewall_lists returns false when the value is unchanged" do
+    cache = build_cache
+    cache.update_runtime_firewall_lists({"blockedIPAddresses" => []})
+
+    refute cache.update_runtime_firewall_lists({"blockedIPAddresses" => []})
+  end
+
+  test "#update_runtime_firewall_lists returns true again once the value changes" do
+    cache = build_cache
+    cache.update_runtime_firewall_lists({"blockedIPAddresses" => []})
+
+    assert cache.update_runtime_firewall_lists({"blockedIPAddresses" => ["1.2.3.4"]})
   end
 
   test "#firewall_lists_if_changed returns the value and generation when the known generation is nil" do

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -21,6 +21,7 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 60, @config.polling_interval
     assert_equal [30, 120], @config.initial_heartbeat_delays
     assert_equal 10, @config.worker_process_polling_interval
+    assert_equal 10, @config.worker_process_polling_jitter
     assert_equal 10, @config.worker_process_heartbeat_interval
     assert_equal Aikido::Zen::Config::DEFAULT_JSON_ENCODER, @config.json_encoder
     assert_equal Aikido::Zen::Config::DEFAULT_JSON_DECODER, @config.json_decoder

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -20,6 +20,8 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
     assert_equal 10, @config.api_timeouts[:write_timeout]
     assert_equal 60, @config.polling_interval
     assert_equal [30, 120], @config.initial_heartbeat_delays
+    assert_equal 10, @config.worker_process_polling_interval
+    assert_equal 10, @config.worker_process_heartbeat_interval
     assert_equal Aikido::Zen::Config::DEFAULT_JSON_ENCODER, @config.json_encoder
     assert_equal Aikido::Zen::Config::DEFAULT_JSON_DECODER, @config.json_decoder
     assert_kind_of ::Logger, @config.logger

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -47,6 +47,11 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
       worker = MockWorker.new
       keepalive_worker = MockWorker.new
 
+      # Ignore the actual delay before polling starts.
+      def worker.delay(*)
+        yield
+      end
+
       agent = Aikido::Zen::WorkerProcess::Agent::Client.new(
         "127.0.0.1",
         12345,
@@ -92,6 +97,57 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
       assert client.started
       assert_equal 2, worker.jobs.size
       assert_equal 1, keepalive_worker.jobs.size
+    end
+  end
+
+  test "#start delays the first poll to reduce the chance of workers polling in lockstep" do
+    client = MockRPCClient.new
+    client.invoke_results["updated_settings"] = {}
+
+    Aikido::Zen::RPC::Client.stub(:new, client) do
+      worker = MockWorker.new
+      keepalive_worker = MockWorker.new
+
+      agent = Aikido::Zen::WorkerProcess::Agent::Client.new(
+        "127.0.0.1",
+        12345,
+        config: Aikido::Zen.config,
+        worker: worker,
+        keepalive_worker: keepalive_worker,
+        collector: Minitest::Mock.new,
+        polling_interval: 10,
+        polling_jitter: 5,
+        heartbeat_interval: 10
+      )
+      agent.start
+
+      assert_equal 1, worker.delayed.size
+      assert_includes 1..5, worker.delayed.first.initial_delay
+    end
+  end
+
+  test "#start does not delay the first poll when polling_jitter is 0" do
+    client = MockRPCClient.new
+    client.invoke_results["updated_settings"] = {}
+
+    Aikido::Zen::RPC::Client.stub(:new, client) do
+      worker = MockWorker.new
+      keepalive_worker = MockWorker.new
+
+      agent = Aikido::Zen::WorkerProcess::Agent::Client.new(
+        "127.0.0.1",
+        12345,
+        config: Aikido::Zen.config,
+        worker: worker,
+        keepalive_worker: keepalive_worker,
+        collector: Minitest::Mock.new,
+        polling_interval: 10,
+        polling_jitter: 0,
+        heartbeat_interval: 10
+      )
+      agent.start
+
+      assert_equal 0, worker.delayed.first.initial_delay
     end
   end
 

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -6,12 +6,13 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
   include WorkerHelpers
 
   class MockRPCClient
-    attr_reader :started, :stopped, :closed, :invoke_results
+    attr_reader :started, :stopped, :closed, :invoke_calls, :invoke_results
 
     def initialize
       @started = false
       @stopped = false
       @closed = false
+      @invoke_calls = []
       @invoke_results = {}
     end
 
@@ -30,9 +31,12 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
 
     def invoke(name, *args, timeout: nil)
+      @invoke_calls << [name, args]
       @invoke_results[name]
     end
   end
+
+  KEEPALIVE_INTERVAL = Aikido::Zen::WorkerProcess::Agent::Client::KEEPALIVE_INTERVAL
 
   def build_agent(invoke_results = {})
     client = MockRPCClient.new
@@ -248,6 +252,171 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "the scheduled polling task logs a debug message when settings change" do
+    config_data = {
+      "configUpdatedAt" => 0,
+      "heartbeatIntervalInMS" => 60_000,
+      "endpoints" => [],
+      "blockedUserIds" => [],
+      "allowedIPAddresses" => [],
+      "receivedAnyStats" => false,
+      "block" => false,
+      "blockNewOutgoingRequests" => false,
+      "domains" => {},
+      "excludedUserIdsFromRateLimiting" => []
+    }
+
+    firewall_data = {
+      "blockedUserAgents" => nil,
+      "monitoredUserAgents" => nil,
+      "userAgentDetails" => [],
+      "blockedIPAddresses" => [],
+      "allowedIPAddresses" => [],
+      "monitoredIPAddresses" => []
+    }
+
+    build_agent("updated_settings" => {
+      "config" => config_data,
+      "config_generation" => 5,
+      "firewall_lists" => firewall_data,
+      "firewall_lists_generation" => 9
+    }) do |agent, worker, collector, client|
+      worker.jobs[0].task.call
+
+      assert_logged :debug, /updated runtime settings from parent/
+    end
+  end
+
+  test "the scheduled polling task does not log when settings are unchanged" do
+    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
+      worker.jobs[0].task.call
+
+      refute_logged :debug, /updated runtime settings from parent/
+    end
+  end
+
+  test "the scheduled polling task sends the known generations to the parent" do
+    config_data = {
+      "configUpdatedAt" => 0,
+      "heartbeatIntervalInMS" => 60_000,
+      "endpoints" => [],
+      "blockedUserIds" => [],
+      "allowedIPAddresses" => [],
+      "receivedAnyStats" => false,
+      "block" => false,
+      "blockNewOutgoingRequests" => false,
+      "domains" => {},
+      "excludedUserIdsFromRateLimiting" => []
+    }
+
+    firewall_data = {
+      "blockedUserAgents" => nil,
+      "monitoredUserAgents" => nil,
+      "userAgentDetails" => [],
+      "blockedIPAddresses" => [],
+      "allowedIPAddresses" => [],
+      "monitoredIPAddresses" => []
+    }
+
+    build_agent("updated_settings" => {
+      "config" => config_data,
+      "config_generation" => 5,
+      "firewall_lists" => firewall_data,
+      "firewall_lists_generation" => 9
+    }) do |agent, worker, collector, client|
+      worker.jobs[0].task.call
+
+      _name, args = client.invoke_calls.last
+      assert_equal [KEEPALIVE_INTERVAL, 5, 9], args
+    end
+  end
+
+  test "the scheduled polling task applies config without firewall_lists" do
+    config_data = {
+      "configUpdatedAt" => 0,
+      "heartbeatIntervalInMS" => 60_000,
+      "endpoints" => [],
+      "blockedUserIds" => [],
+      "allowedIPAddresses" => [],
+      "receivedAnyStats" => false,
+      "block" => false,
+      "blockNewOutgoingRequests" => false,
+      "domains" => {},
+      "excludedUserIdsFromRateLimiting" => []
+    }
+
+    build_agent("updated_settings" => {
+      "config" => config_data,
+      "config_generation" => 5
+    }) do |agent, worker, collector, client|
+      worker.jobs[0].task.call
+
+      assert_equal 60, Aikido::Zen.runtime_settings.heartbeat_interval
+
+      _name, args = client.invoke_calls.last
+      assert_equal [KEEPALIVE_INTERVAL, 5, nil], args
+    end
+  end
+
+  test "the scheduled polling task applies firewall_lists without config" do
+    firewall_data = {
+      "blockedUserAgents" => nil,
+      "monitoredUserAgents" => nil,
+      "userAgentDetails" => [],
+      "blockedIPAddresses" => [],
+      "allowedIPAddresses" => [],
+      "monitoredIPAddresses" => []
+    }
+
+    build_agent("updated_settings" => {
+      "firewall_lists" => firewall_data,
+      "firewall_lists_generation" => 9
+    }) do |agent, worker, collector, client|
+      worker.jobs[0].task.call
+
+      _name, args = client.invoke_calls.last
+      assert_equal [KEEPALIVE_INTERVAL, nil, 9], args
+    end
+  end
+
+  test "the scheduled polling task keeps the known generations when settings are unchanged" do
+    config_data = {
+      "configUpdatedAt" => 0,
+      "heartbeatIntervalInMS" => 60_000,
+      "endpoints" => [],
+      "blockedUserIds" => [],
+      "allowedIPAddresses" => [],
+      "receivedAnyStats" => false,
+      "block" => false,
+      "blockNewOutgoingRequests" => false,
+      "domains" => {},
+      "excludedUserIdsFromRateLimiting" => []
+    }
+
+    firewall_data = {
+      "blockedUserAgents" => nil,
+      "monitoredUserAgents" => nil,
+      "userAgentDetails" => [],
+      "blockedIPAddresses" => [],
+      "allowedIPAddresses" => [],
+      "monitoredIPAddresses" => []
+    }
+
+    build_agent("updated_settings" => {
+      "config" => config_data,
+      "config_generation" => 5,
+      "firewall_lists" => firewall_data,
+      "firewall_lists_generation" => 9
+    }) do |agent, worker, collector, client|
+      client.invoke_results["updated_settings"] = {}
+
+      assert_nothing_raised { worker.jobs[0].task.call }
+
+      _name, args = client.invoke_calls.last
+      assert_equal [KEEPALIVE_INTERVAL, 5, 9], args
+    end
+  end
+
   test "the scheduled polling task logs an error when the RPC call raises" do
     build_agent("updated_settings" => {}) do |agent, worker, collector, client|
       client.stub(:invoke, ->(*) { raise "boom" }) do
@@ -357,6 +526,7 @@ class Aikido::Zen::WorkerProcess::Agent::ClientIntegrationTest < ActiveSupport::
 
   test "client reconnects and updates settings after the connection drops" do
     connections = Concurrent::AtomicFixnum.new(0)
+    generations = Concurrent::AtomicFixnum.new(0)
 
     config = -> do
       {
@@ -368,20 +538,25 @@ class Aikido::Zen::WorkerProcess::Agent::ClientIntegrationTest < ActiveSupport::
       }
     end
 
+    # Simulates the config having changed every poll.
+    next_generation = -> { generations.increment }
+
     Aikido::Zen.api_cache.stub(:runtime_config, config) do
-      in_forked_worker do
-        client = build_client
-        client.start
+      Aikido::Zen.api_cache.stub(:runtime_config_generation, next_generation) do
+        in_forked_worker do
+          client = build_client
+          client.start
 
-        wait_until(timeout: 2.0) { Aikido::Zen.runtime_settings.heartbeat_interval == 1 }
+          wait_until(timeout: 2.0) { Aikido::Zen.runtime_settings.heartbeat_interval == 1 }
 
-        client.instance_variable_get(:@rpc_client).instance_variable_get(:@client)
-          .socket.shutdown(Socket::SHUT_RDWR)
+          client.instance_variable_get(:@rpc_client).instance_variable_get(:@client)
+            .socket.shutdown(Socket::SHUT_RDWR)
 
-        wait_until(timeout: 2.0) { Aikido::Zen.runtime_settings.heartbeat_interval == 2 }
+          wait_until(timeout: 2.0) { Aikido::Zen.runtime_settings.heartbeat_interval == 2 }
 
-        interval = Aikido::Zen.runtime_settings.heartbeat_interval
-        raise "expected heartbeat_interval=2 after reconnecting, got #{interval}" unless interval == 2
+          interval = Aikido::Zen.runtime_settings.heartbeat_interval
+          raise "expected heartbeat_interval=2 after reconnecting, got #{interval}" unless interval == 2
+        end
       end
     end
   end

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -172,21 +172,6 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "#start logs an error when the RPC call raises" do
-    client = MockRPCClient.new
-
-    client.stub(:invoke, ->(*) { raise "boom" }) do
-      Aikido::Zen::RPC::Client.stub(:new, client) do
-        worker = MockWorker.new
-        agent = Aikido::Zen::WorkerProcess::Agent::Client.new("127.0.0.1", 12345, worker: worker)
-
-        agent.start
-
-        assert_logged :error, /failed to get settings after connecting to parent: boom/
-      end
-    end
-  end
-
   test "#stop does stop the RPC client and does shut down the worker" do
     build_agent("updated_settings" => {}) do |agent, worker, collector, client, keepalive_worker|
       agent.stop
@@ -524,7 +509,9 @@ class Aikido::Zen::WorkerProcess::Agent::ClientIntegrationTest < ActiveSupport::
     Aikido::Zen::WorkerProcess::Agent::Client.new(
       @server.host, @server.port,
       worker: Aikido::Zen::Worker.new,
-      collector: Aikido::Zen.collector
+      collector: Aikido::Zen.collector,
+      polling_interval: 1,
+      polling_jitter: 0
     )
   end
 

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -324,7 +324,8 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     }) do |agent, worker, collector, client|
       worker.jobs[0].task.call
 
-      assert_logged :debug, /updated runtime settings from parent/
+      assert_logged :debug, /starting runtime settings update/
+      assert_logged :debug, /finished runtime settings update/
     end
   end
 
@@ -332,7 +333,7 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     build_agent("updated_settings" => {}) do |agent, worker, collector, client|
       worker.jobs[0].task.call
 
-      refute_logged :debug, /updated runtime settings from parent/
+      refute_logged :debug, /runtime settings update/
     end
   end
 

--- a/test/aikido/zen/worker_process/agent/server_test.rb
+++ b/test/aikido/zen/worker_process/agent/server_test.rb
@@ -127,6 +127,92 @@ class Aikido::Zen::WorkerProcess::Agent::ServerTest < ActiveSupport::TestCase
     assert_equal firewall_lists, settings["firewall_lists"]
   end
 
+  test "#updated_settings includes config_generation and firewall_lists_generation" do
+    Aikido::Zen.api_cache.runtime_config = {"configUpdatedAt" => 1234567890}
+    Aikido::Zen.api_cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    settings = @server.updated_settings
+
+    assert_equal Aikido::Zen.api_cache.runtime_config_generation, settings["config_generation"]
+    assert_equal Aikido::Zen.api_cache.runtime_firewall_lists_generation, settings["firewall_lists_generation"]
+  end
+
+  test "#updated_settings does not include config when the generation is unchanged" do
+    Aikido::Zen.api_cache.runtime_config = {"configUpdatedAt" => 1234567890}
+    current_generation = Aikido::Zen.api_cache.runtime_config_generation
+
+    settings = @server.updated_settings(current_generation)
+
+    refute settings.key?("config")
+    refute settings.key?("config_generation")
+  end
+
+  test "#updated_settings includes config again once it changes" do
+    Aikido::Zen.api_cache.runtime_config = {"configUpdatedAt" => 1}
+    stale_generation = Aikido::Zen.api_cache.runtime_config_generation
+
+    Aikido::Zen.api_cache.runtime_config = {"configUpdatedAt" => 2}
+
+    settings = @server.updated_settings(stale_generation)
+
+    assert_equal({"configUpdatedAt" => 2}, settings["config"])
+    assert_equal Aikido::Zen.api_cache.runtime_config_generation, settings["config_generation"]
+  end
+
+  test "updated_settings handler does not include config when the generation is unchanged" do
+    Aikido::Zen.api_cache.runtime_config = {"configUpdatedAt" => 1234567890}
+    Aikido::Zen.api_cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    result = client.invoke("updated_settings", 2.0, Aikido::Zen.api_cache.runtime_config_generation)
+
+    refute result.key?("config")
+    refute result.key?("config_generation")
+    assert result.key?("firewall_lists")
+  ensure
+    client.stop
+  end
+
+  test "#updated_settings does not include firewall_lists when the generation is unchanged" do
+    Aikido::Zen.api_cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+    current_generation = Aikido::Zen.api_cache.runtime_firewall_lists_generation
+
+    settings = @server.updated_settings(nil, current_generation)
+
+    refute settings.key?("firewall_lists")
+    refute settings.key?("firewall_lists_generation")
+  end
+
+  test "#updated_settings includes firewall_lists again once it changes" do
+    Aikido::Zen.api_cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+    stale_generation = Aikido::Zen.api_cache.runtime_firewall_lists_generation
+
+    Aikido::Zen.api_cache.runtime_firewall_lists = {"blockedIPAddresses" => ["1.2.3.4"]}
+
+    settings = @server.updated_settings(nil, stale_generation)
+
+    assert_equal({"blockedIPAddresses" => ["1.2.3.4"]}, settings["firewall_lists"])
+    assert_equal Aikido::Zen.api_cache.runtime_firewall_lists_generation, settings["firewall_lists_generation"]
+  end
+
+  test "updated_settings handler does not include firewall_lists when the generation is unchanged" do
+    Aikido::Zen.api_cache.runtime_config = {"configUpdatedAt" => 1234567890}
+    Aikido::Zen.api_cache.runtime_firewall_lists = {"blockedIPAddresses" => []}
+
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    result = client.invoke("updated_settings", 2.0, nil, Aikido::Zen.api_cache.runtime_firewall_lists_generation)
+
+    refute result.key?("firewall_lists")
+    refute result.key?("firewall_lists_generation")
+    assert result.key?("config")
+  ensure
+    client.stop
+  end
+
   test "send_collector_events handler pushes events into the collector" do
     input_events = Array.new(3) { Aikido::Zen::Collector::Events::TrackRequest.new }
     input_events_data = input_events.map(&:as_json)

--- a/test/rails/e2e/rails7.2_generic/config/initializers/zen.rb
+++ b/test/rails/e2e/rails7.2_generic/config/initializers/zen.rb
@@ -3,6 +3,7 @@ if Rails.application.config.respond_to?(:zen)
   zen.blocking_mode = true
   zen.polling_interval = 1
   zen.worker_process_polling_interval = 1
+  zen.worker_process_polling_jitter = 0
   zen.worker_process_heartbeat_interval = 1
   zen.realtime_settings_updates_enabled = true
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,7 @@ class ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@collector, collector)
 
     Aikido::Zen.instance_variable_set(:@runtime_settings, nil)
+    Aikido::Zen.instance_variable_set(:@api_cache, nil)
     Aikido::Zen.instance_variable_set(:@rate_limiter, Aikido::Zen::RateLimiter.new)
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
     Aikido::Zen.instance_variable_set(:@worker_process_server, nil)


### PR DESCRIPTION
This change optimizes realtime settings updates across processes, by adding generations to the `Aikido::Zen::APICache` -- the generation is incremented whenever the cached value changes -- so that the runtime settings are only updated when the config or firewall lists are updated, and staggering when worker processes start polling by a random jitter between 1 and `Aikido::Zen::Config#worker_process_polling_jitter` seconds and removing automatic runtime settings update when the client (re)connects, to spread the load.

These optimizations work together to reduce the frequency of updates and (probabilistically) distribute updates over time to prevent CPU saturation while updating (primarily) large firewall lists in parallel across multiple processes.

The API cache is now the source of truth for when the config or firewall lists should be updated, and the main process now uses the same cache to decide whether to update its runtime settings (`configUpdatedAt` is also checked for the config).

The change also includes significant improvements to logging, necessary for debugging.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 4 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added generation counters to APICache and conditional change retrieval.
* Introduced worker_process_polling_jitter and randomized delay for polling startup.
* Made worker RPC exchange generation-aware settings and avoided redundant updates.
* Stopped runtime settings update on reconnect and improved update staggering.
* Improved logging around runtime settings updates for better observability.

**🔧 Refactors**
* Refactored APICache setters to update methods and added readers.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152588848?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->