### PR TITLE
Optimize IPList using integer ranges

### DIFF
--- a/lib/aikido/zen/runtime_settings/ip_list.rb
+++ b/lib/aikido/zen/runtime_settings/ip_list.rb
@@ -29,10 +29,13 @@ module Aikido::Zen
       @ipv6_ranges = []
 
       ips.each do |ip|
+        range = ip.to_range
+        ip_int_range = (range.begin.to_i..range.end.to_i)
+
         if ip.ipv4?
-          @ipv4_ranges << ip.to_range
+          @ipv4_ranges << ip_int_range
         elsif ip.ipv6?
-          @ipv6_ranges << ip.to_range
+          @ipv6_ranges << ip_int_range
         else
           raise ArgumentError, "Unsupported IP address family: #{ip.inspect}"
         end
@@ -50,10 +53,12 @@ module Aikido::Zen
       native_ip = nativize_ip(ip)
       return false if native_ip.nil?
 
+      ip_int = native_ip.to_i
+
       if native_ip.ipv4?
-        ranges_cover?(@ipv4_ranges, native_ip)
+        ranges_cover?(@ipv4_ranges, ip_int)
       elsif native_ip.ipv6?
-        ranges_cover?(@ipv6_ranges, native_ip)
+        ranges_cover?(@ipv6_ranges, ip_int)
       else
         raise ArgumentError, "Unsupported IP address family: #{ip.inspect}"
       end
@@ -78,12 +83,12 @@ module Aikido::Zen
       end
     end
 
-    def ranges_cover?(ranges, ip)
-      index = ranges.bsearch_index { |range| range.begin > ip }
+    def ranges_cover?(ranges, ip_int)
+      index = ranges.bsearch_index { |range| range.begin > ip_int }
       index = index ? index - 1 : ranges.size - 1
       return false if index < 0
 
-      ranges[index].cover?(ip)
+      ranges[index].cover?(ip_int)
     end
   end
 end

--- a/test/aikido/zen/runtime_settings/ip_list_test.rb
+++ b/test/aikido/zen/runtime_settings/ip_list_test.rb
@@ -32,6 +32,11 @@ class Aikido::Zen::RuntimeSettings::IPListTest < ActiveSupport::TestCase
     assert_equal 10, ip_list.ips.size
     assert_equal 5, ip_list.ipv4_ranges.size
     assert_equal 5, ip_list.ipv6_ranges.size
+
+    assert_kind_of Integer, ip_list.ipv4_ranges.first.begin
+    assert_kind_of Integer, ip_list.ipv4_ranges.first.end
+    assert_kind_of Integer, ip_list.ipv6_ranges.first.begin
+    assert_kind_of Integer, ip_list.ipv6_ranges.first.end
   end
 
   test "#include? is true if the ip address is included" do
@@ -70,6 +75,7 @@ class Aikido::Zen::RuntimeSettings::IPListTest < ActiveSupport::TestCase
       "fe80::ffff:ffff:ffff:ffff"
     ].each do |ip|
       assert ip_list.include?(ip)
+      assert ip_list.include?(IPAddr.new(ip))
     end
   end
 


### PR DESCRIPTION
This change reduced memory usage for firewall lists by storing integer IP ranges in `Aikido::Zen::RuntimeSettings::IPLists`. This works because Ruby `Integer`s use less heap space than `IPAddr`s; small integers are immediate values that consume no heap space while big integers consume less heap space than `IPAddr`.

An IP range is represented by `Range` with a first and last IP address. IPv4 addresses can be represented by 4 bytes but consume 80 bytes of heap space when represented by an `IPAddr`.  IPv6 addresses can be represented by 16 bytes but consume 160 bytes of heap space when represented by an `IPAddr`, and 40 bytes when represented by a big integer.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Optimized IP lists to store integer IP ranges for memory

**🔧 Refactors**
* Refactored inclusion logic to compare integer addresses and ranges


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153488237?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->