### PR TITLE
Support gradual rollout flag for realtime updates

### DIFF
--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -71,7 +71,7 @@ module Aikido::Zen
         if update_settings_from_runtime_config!(response, reason: "after start")
           updated_settings!
 
-          if @config.realtime_settings_updates_enabled? || @settings.realtime_settings_updates_enabled
+          if @config.realtime_settings_updates_enabled? || @settings.realtime_settings_updates_enabled?
             @api_stream.handle("config-updated") do |event|
               @config.logger.debug("Received server-sent event: config-updated")
               settings_updated(event)

--- a/lib/aikido/zen/agent.rb
+++ b/lib/aikido/zen/agent.rb
@@ -18,12 +18,14 @@ module Aikido::Zen
 
     def initialize(
       config: Aikido::Zen.config,
+      settings: Aikido::Zen.runtime_settings,
       collector: Aikido::Zen.collector,
       worker: Aikido::Zen::Worker.new(config: config),
       api_client: Aikido::Zen::APIClient.new(config: config),
       api_stream: Aikido::Zen::APIStream.new(config: config)
     )
       @config = config
+      @settings = settings
       @collector = collector
       @worker = worker
       @api_client = api_client
@@ -68,6 +70,15 @@ module Aikido::Zen
       report(Events::Started.new(time: @started_at)) do |response|
         if update_settings_from_runtime_config!(response, reason: "after start")
           updated_settings!
+
+          if @config.realtime_settings_updates_enabled? || @settings.realtime_settings_updates_enabled
+            @api_stream.handle("config-updated") do |event|
+              @config.logger.debug("Received server-sent event: config-updated")
+              settings_updated(event)
+            end
+
+            @api_stream.start!
+          end
         # :nocov:
         else
           # empty
@@ -81,15 +92,6 @@ module Aikido::Zen
         update_settings_from_runtime_firewall_lists!(@api_client.fetch_runtime_firewall_lists, reason: "after start")
       rescue => err
         @config.logger.error(err.message)
-      end
-
-      if @config.realtime_settings_updates_enabled?
-        @api_stream.handle("config-updated") do |event|
-          @config.logger.debug("Received server-sent event: config-updated")
-          settings_updated(event)
-        end
-
-        @api_stream.start!
       end
 
       poll_for_setting_updates
@@ -197,7 +199,7 @@ module Aikido::Zen
     # @return [void]
     # @see Aikido::Zen::RuntimeSettings
     def poll_for_setting_updates
-      @worker.every(@config.polling_interval) do
+      @worker.every(@config.polling_interval, run_now: true) do
         if @api_client.should_fetch_settings?
           if update_settings_from_runtime_config!(@api_client.fetch_runtime_config, reason: "after polling")
             updated_settings!

--- a/lib/aikido/zen/runtime_settings.rb
+++ b/lib/aikido/zen/runtime_settings.rb
@@ -11,7 +11,8 @@ module Aikido::Zen
   #
   # You can subscribe to changes with +#add_observer(object, func_name)+, which
   # will call the function passing the settings as an argument
-  RuntimeSettings = Struct.new(:updated_at,
+  RuntimeSettings = Struct.new(
+    :updated_at,
     :heartbeat_interval,
     :endpoints,
     :blocked_user_ids,

--- a/lib/aikido/zen/runtime_settings.rb
+++ b/lib/aikido/zen/runtime_settings.rb
@@ -11,7 +11,24 @@ module Aikido::Zen
   #
   # You can subscribe to changes with +#add_observer(object, func_name)+, which
   # will call the function passing the settings as an argument
-  RuntimeSettings = Struct.new(:updated_at, :heartbeat_interval, :endpoints, :blocked_user_ids, :bypassed_ips, :received_any_stats, :blocking_mode, :blocked_user_agent_regexp, :monitored_user_agent_regexp, :user_agent_details, :blocked_ip_lists, :allowed_ip_lists, :monitored_ip_lists, :block_new_outbound, :domains, :excluded_user_ids_from_rate_limiting) do
+  RuntimeSettings = Struct.new(:updated_at,
+    :heartbeat_interval,
+    :endpoints,
+    :blocked_user_ids,
+    :bypassed_ips,
+    :received_any_stats,
+    :blocking_mode,
+    :blocked_user_agent_regexp,
+    :monitored_user_agent_regexp,
+    :user_agent_details,
+    :blocked_ip_lists,
+    :allowed_ip_lists,
+    :monitored_ip_lists,
+    :block_new_outbound,
+    :domains,
+    :excluded_user_ids_from_rate_limiting,
+    :realtime_settings_updates_enabled
+  ) do
     def initialize(*)
       super
       self.endpoints ||= RuntimeSettings::Endpoints.new
@@ -20,6 +37,7 @@ module Aikido::Zen
       self.allowed_ip_lists ||= []
       self.monitored_ip_lists ||= []
       self.domains ||= RuntimeSettings::Domains.new
+      self.realtime_settings_updates_enabled = false
     end
 
     # @!attribute [rw] updated_at
@@ -73,6 +91,9 @@ module Aikido::Zen
     #   @return [Array<String>, nil] the user IDs that should be skipped from
     #     rate limiting entirely.
 
+    # @!attribute [rw] realtime_settings_updates_enabled
+    #   @return [Boolean]
+
     # Parse and interpret the JSON response from the core API with updated
     # runtime settings, and apply the changes.
     #
@@ -96,6 +117,8 @@ module Aikido::Zen
       self.domains = RuntimeSettings::Domains.from_json(data["domains"])
 
       self.excluded_user_ids_from_rate_limiting = data["excludedUserIdsFromRateLimiting"]
+
+      self.realtime_settings_updates_enabled = data["realtimeUpdatesEnabled"]
 
       updated_at != last_updated_at
     end

--- a/lib/aikido/zen/runtime_settings.rb
+++ b/lib/aikido/zen/runtime_settings.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Aikido::Zen
   # Stores the firewall configuration sourced from the Aikido dashboard. This
   # object is updated by the Agent regularly.
@@ -28,7 +30,7 @@ module Aikido::Zen
     :block_new_outbound,
     :domains,
     :excluded_user_ids_from_rate_limiting,
-    :realtime_settings_updates_enabled
+    :enabled_features
   ) do
     def initialize(*)
       super
@@ -38,7 +40,7 @@ module Aikido::Zen
       self.allowed_ip_lists ||= []
       self.monitored_ip_lists ||= []
       self.domains ||= RuntimeSettings::Domains.new
-      self.realtime_settings_updates_enabled = false
+      self.enabled_features ||= Set.new
     end
 
     # @!attribute [rw] updated_at
@@ -92,8 +94,8 @@ module Aikido::Zen
     #   @return [Array<String>, nil] the user IDs that should be skipped from
     #     rate limiting entirely.
 
-    # @!attribute [rw] realtime_settings_updates_enabled
-    #   @return [Boolean]
+    # @!attribute [rw] enabled_features
+    #   @return [Set<String>]
 
     # Parse and interpret the JSON response from the core API with updated
     # runtime settings, and apply the changes.
@@ -119,7 +121,7 @@ module Aikido::Zen
 
       self.excluded_user_ids_from_rate_limiting = data["excludedUserIdsFromRateLimiting"]
 
-      self.realtime_settings_updates_enabled = data["realtimeUpdatesEnabled"]
+      self.enabled_features = Set.new(data["enabledFeatures"])
 
       updated_at != last_updated_at
     end
@@ -246,6 +248,14 @@ module Aikido::Zen
       domain = domains[connection.host]
 
       (!domain.nil? && domain.block?) || (domain.nil? && block_new_outbound)
+    end
+
+    private def enabled_feature?(feature)
+      enabled_features.include?(feature)
+    end
+
+    def realtime_settings_updates_enabled?
+      enabled_feature?("realtime_updates")
     end
   end
 end

--- a/test/aikido/zen/agent_test.rb
+++ b/test/aikido/zen/agent_test.rb
@@ -212,7 +212,7 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     @config.realtime_settings_updates_enabled = false
 
     @api_client.expect :report,
-      {"configUpdatedAt" => 1234567890, "realtimeUpdatesEnabled" => true},
+      {"configUpdatedAt" => 1234567890, "enabledFeatures" => ["realtime_updates"]},
       [Aikido::Zen::Events::Started]
 
     @agent.start!
@@ -227,7 +227,7 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     @config.realtime_settings_updates_enabled = false
 
     @api_client.expect :report,
-      {"configUpdatedAt" => 1234567890, "realtimeUpdatesEnabled" => false},
+      {"configUpdatedAt" => 1234567890, "enabledFeatures" => []},
       [Aikido::Zen::Events::Started]
 
     @agent.start!

--- a/test/aikido/zen/agent_test.rb
+++ b/test/aikido/zen/agent_test.rb
@@ -208,6 +208,45 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
     assert_empty @api_stream.instance_variable_get(:@handlers)
   end
 
+  test "#start! starts the api_stream when the runtime settings response enables realtime updates, even if the config flag is off" do
+    @config.realtime_settings_updates_enabled = false
+
+    @api_client.expect :report,
+      {"configUpdatedAt" => 1234567890, "realtimeUpdatesEnabled" => true},
+      [Aikido::Zen::Events::Started]
+
+    @agent.start!
+
+    assert @api_stream.started?
+    refute_empty @api_stream.instance_variable_get(:@handlers)
+
+    assert_mock @api_client
+  end
+
+  test "#start! does not start the api_stream when neither the config flag nor the runtime settings enable realtime updates" do
+    @config.realtime_settings_updates_enabled = false
+
+    @api_client.expect :report,
+      {"configUpdatedAt" => 1234567890, "realtimeUpdatesEnabled" => false},
+      [Aikido::Zen::Events::Started]
+
+    @agent.start!
+
+    refute @api_stream.started?
+    assert_empty @api_stream.instance_variable_get(:@handlers)
+
+    assert_mock @api_client
+  end
+
+  test "#start! does not start the api_stream until the initial settings update actually applies changes" do
+    @agent.stub :update_settings_from_runtime_config!, ->(*) { false } do
+      @agent.start!
+    end
+
+    refute @api_stream.started?
+    assert_empty @api_stream.instance_variable_get(:@handlers)
+  end
+
   test "#start! starts polling for setting updates every minute" do
     @api_client.expect :should_fetch_settings?, false
 

--- a/test/aikido/zen/runtime_settings_test.rb
+++ b/test/aikido/zen/runtime_settings_test.rb
@@ -113,6 +113,18 @@ class Aikido::Zen::RuntimeSettingsTest < ActiveSupport::TestCase
     refute @settings.user_excluded_from_rate_limiting?(nil)
   end
 
+  test "#realtime_settings_updates_enabled defaults to false" do
+    assert_equal false, @settings.realtime_settings_updates_enabled
+  end
+
+  test "#update_from_runtime_config_json sets realtime_settings_updates_enabled" do
+    @settings.update_from_runtime_config_json({"realtimeUpdatesEnabled" => true})
+    assert_equal true, @settings.realtime_settings_updates_enabled
+
+    @settings.update_from_runtime_config_json({"realtimeUpdatesEnabled" => false})
+    assert_equal false, @settings.realtime_settings_updates_enabled
+  end
+
   test "#user_excluded_from_rate_limiting? returns false when the list is nil" do
     refute @settings.user_excluded_from_rate_limiting?("user1")
   end

--- a/test/aikido/zen/runtime_settings_test.rb
+++ b/test/aikido/zen/runtime_settings_test.rb
@@ -113,16 +113,16 @@ class Aikido::Zen::RuntimeSettingsTest < ActiveSupport::TestCase
     refute @settings.user_excluded_from_rate_limiting?(nil)
   end
 
-  test "#realtime_settings_updates_enabled defaults to false" do
-    assert_equal false, @settings.realtime_settings_updates_enabled
+  test "#update_from_runtime_config_json sets enabled_features" do
+    @settings.update_from_runtime_config_json({"enabledFeatures" => ["realtime_updates"]})
+    assert_includes @settings.enabled_features, "realtime_updates"
+
+    @settings.update_from_runtime_config_json({"enabledFeatures" => []})
+    refute_includes @settings.enabled_features, "realtime_updates"
   end
 
-  test "#update_from_runtime_config_json sets realtime_settings_updates_enabled" do
-    @settings.update_from_runtime_config_json({"realtimeUpdatesEnabled" => true})
-    assert_equal true, @settings.realtime_settings_updates_enabled
-
-    @settings.update_from_runtime_config_json({"realtimeUpdatesEnabled" => false})
-    assert_equal false, @settings.realtime_settings_updates_enabled
+  test "#realtime_settings_updates_enabled? defaults to false" do
+    assert_equal false, @settings.realtime_settings_updates_enabled?
   end
 
   test "#user_excluded_from_rate_limiting? returns false when the list is nil" do


### PR DESCRIPTION
This change exposes the new `realtimeUpdatesEnabled` flag from the runtime config response as `Aikido::Zen::RuntimeSettings#realtime_settings_updates_enabled`, and only starts the API stream once the first settings update has been applied and either `Aikido::Zen::RuntimeSettings#realtime_settings_updates_enabled`  or `Aikido::Zen::Config#realtime_settings_updates_enabled` is truthy.