### PR TITLE
Add Retry-After to rate-limited responses

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -77,7 +77,9 @@ Aikido::Zen.rate_limited_responder = ->(request) {
 }
 ```
 
-By default, Zen emits a `text/plain` 429 response that says "Too many requests".
+By default, Zen emits a `text/plain` 429 response that says "Too many requests"
+and includes a `Retry-After` header with the number of seconds until the rate
+limit window resets.
 
 ### Providing details about the rate limiting
 

--- a/lib/aikido/zen/config.rb
+++ b/lib/aikido/zen/config.rb
@@ -409,7 +409,13 @@ module Aikido::Zen
 
     # @!visibility private
     DEFAULT_RATE_LIMITED_RESPONDER = ->(request) do
-      [429, {"Content-Type" => "text/plain"}, ["Too many requests."]]
+      rate_limit = request.env["aikido.rate_limiting"]
+      headers = {
+        "Content-Type" => "text/plain",
+        "Retry-After" => rate_limit.time_remaining.to_s
+      }
+
+      [429, headers, ["Too many requests."]]
     end
 
     # @!visibility private

--- a/test/aikido/zen/config_test.rb
+++ b/test/aikido/zen/config_test.rb
@@ -235,10 +235,13 @@ class Aikido::Zen::ConfigTest < ActiveSupport::TestCase
   end
 
   test " the default #rate_limited_responder returns the expected Rack response" do
-    status, headers, body = @config.rate_limited_responder.call(Object.new)
+    rate_limit = OpenStruct.new(time_remaining: 42)
+    request = OpenStruct.new(env: {"aikido.rate_limiting" => rate_limit})
+
+    status, headers, body = @config.rate_limited_responder.call(request)
 
     assert_equal 429, status
-    assert_equal({"Content-Type" => "text/plain"}, headers)
+    assert_equal({"Content-Type" => "text/plain", "Retry-After" => "42"}, headers)
     assert_equal ["Too many requests."], body
   end
 

--- a/test/aikido/zen/middleware/rack_throttler_test.rb
+++ b/test/aikido/zen/middleware/rack_throttler_test.rb
@@ -86,7 +86,7 @@ class Aikido::Zen::Middleware::RackThrottlerTest < ActiveSupport::TestCase
     assert_equal 5, env["aikido.rate_limiting"].time_remaining
 
     response = @middleware.call(env)
-    assert_equal [429, {"Content-Type" => "text/plain"}, ["Too many requests."]], response
+    assert_equal [429, {"Content-Type" => "text/plain", "Retry-After" => "5"}, ["Too many requests."]], response
 
     assert_equal true, env["aikido.rate_limiting"].throttled?
     assert_equal "1.2.3.4", env["aikido.rate_limiting"].discriminator


### PR DESCRIPTION
## Summary

- add a numeric `Retry-After` header to the default 429 rate-limit response
- use the rate limiter's existing `time_remaining` value for the delay
- document the default header and cover it in responder and Rack middleware tests

## Root cause

The rate limiter already attached the remaining window to `request.env["aikido.rate_limiting"]`, but the default responder discarded that information and returned only `Content-Type`. As a result, clients received a 429 without knowing when to retry.

Custom `rate_limited_responder` callbacks are unchanged.

## Validation

- config, Rack middleware, and Action Controller tests: 50 tests, 312 assertions, 0 failures
- StandardRB on all changed Ruby files
- firewall-tester-action Compose `test-rate-limiting-retry-after`: passed in 5.05 seconds against the latest Ruby demo app using this branch as a local path dependency

Before this change, the same Compose test reported five rate-limited responses without a `Retry-After` header.
