### PR TITLE
Fix nil context breaks ActionController::Live

### DIFF
--- a/lib/aikido/zen/rails_engine.rb
+++ b/lib/aikido/zen/rails_engine.rb
@@ -4,6 +4,31 @@ require "action_dispatch"
 
 module Aikido::Zen
   class RailsEngine < ::Rails::Engine
+    # ActionController::Live runs the whole action in a new Thread so that
+    # the original thread can be freed to handle the next request once the
+    # response headers are committed.
+    #
+    # Zen stores the current context on the current Fiber, and propagates
+    # this context to new Fibers created with Fiber.new. The root Fiber of
+    # a new Thread is not created with Fiber.new so the current context is
+    # not propagated automatically.
+    #
+    # Propagate the current context to the root Fiber of the new Thread
+    # created by ActionController::Live to run the action.
+    module LiveThreadContextSetter
+      private
+
+      def new_controller_thread(&blk)
+        context = Aikido::Zen.current_context
+
+        super do
+          Fiber.current.aikido_current_context = context
+
+          blk.call
+        end
+      end
+    end
+
     config.before_configuration do
       # Access library configuration at `Rails.application.config.zen`.
       config.zen = Aikido::Zen.config
@@ -39,6 +64,8 @@ module Aikido::Zen
       end
 
       ActiveSupport.on_load(:action_controller) do
+        ::ActionController::Live.prepend(Aikido::Zen::RailsEngine::LiveThreadContextSetter)
+
         before_action do
           Aikido::Zen.enable_idor_protection if Aikido::Zen.config.idor_protection_enabled?
         end

--- a/test/rails/rails7.2_generic/app/controllers/streams_controller.rb
+++ b/test/rails/rails7.2_generic/app/controllers/streams_controller.rb
@@ -1,0 +1,18 @@
+class StreamsController < ApplicationController
+  include ActionController::Live
+
+  # Simulates a live notifications feed: the client passes its session token
+  # so the server can confirm who's connecting before it starts streaming.
+  def show
+    token = params[:token]
+    return render json: {error: "No token param"}, status: :unauthorized unless token
+
+    ActiveRecord::Base.connection.exec_query(
+      "SELECT name FROM users WHERE token = '#{token}'"
+    )
+
+    response.headers["Content-Type"] = "text/event-stream"
+    response.stream.write("data: ok\n\n")
+    response.stream.close
+  end
+end

--- a/test/rails/rails7.2_generic/config/routes.rb
+++ b/test/rails/rails7.2_generic/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", :as => :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", :as => :pwa_manifest
 
+  get "streams" => "streams#show"
+
   # Defines the root path route ("/")
   # root "posts#index"
 

--- a/test/rails/rails7.2_generic/test/integration/streams_test.rb
+++ b/test/rails/rails7.2_generic/test/integration/streams_test.rb
@@ -10,6 +10,17 @@ ActionController::Live.class_eval do
 end
 
 class StreamsTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.load_seed
+  end
+
+  test "streams successfully" do
+    get "/streams", params: {token: "abc123"}
+
+    assert_response :success
+    assert_equal "data: ok\n\n", response.body
+  end
+
   # Regression test for https://github.com/AikidoSec/firewall-ruby/issues/357.
   test "detects SQL injection in param from within the Live thread" do
     get "/streams", params: {token: "' OR 1=1--"}

--- a/test/rails/rails7.2_generic/test/integration/streams_test.rb
+++ b/test/rails/rails7.2_generic/test/integration/streams_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+# ActionController::Live runs the action in its own thread, where Zen's
+# fiber-local context reads back as nil. rails/test_help stubs that thread away,
+# so put it back to get the production behaviour under test.
+ActionController::Live.class_eval do
+  def new_controller_thread
+    Thread.new { yield }.join
+  end
+end
+
+class StreamsTest < ActionDispatch::IntegrationTest
+  # Regression test for https://github.com/AikidoSec/firewall-ruby/issues/357.
+  test "detects SQL injection in param from within the Live thread" do
+    get "/streams", params: {token: "' OR 1=1--"}
+
+    assert_response :internal_server_error
+  end
+end


### PR DESCRIPTION
This change addresses issue #362.

The current context is now propagated from the current Fiber to the root Fiber of the new Thread created by `ActionController::Live` to handle the live action (stream).