### PR TITLE
Fix exceptions_app breaks attack wave detection

### DIFF
--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -35,7 +35,7 @@ module Aikido::Zen
         context.request.then do |request|
           @samples[client_ip] <<= Sample.new(
             verb: request.request_method,
-            path: request.fullpath
+            path: AttackWave::Helpers.original_fullpath(request)
           )
         end
 

--- a/lib/aikido/zen/attack_wave/helpers.rb
+++ b/lib/aikido/zen/attack_wave/helpers.rb
@@ -16,7 +16,26 @@ module Aikido::Zen
       def self.suspicious_request?(context, status_code)
         request = context.request
 
-        suspicious_method?(request.request_method) || suspicious_path?(request.path_info, status_code)
+        suspicious_method?(request.request_method) || suspicious_path?(original_path(request), status_code)
+      end
+
+      # Rails rewrites PATH_INFO to /status before invoking an exceptions_app.
+      # Returns the path that Rails rewrote.
+      # @param request [Aikido::Zen::Request]
+      # @return [String]
+      def self.original_path(request)
+        request.env["action_dispatch.original_path"] || request.path_info
+      end
+
+      # Rails rewrites PATH_INFO to /status before invoking an exceptions_app.
+      # Returns the path that Rails rewrote, including the same query string.
+      # @param request [Aikido::Zen::Request]
+      # @return [String]
+      def self.original_fullpath(request)
+        path = original_path(request)
+        query = request.query_string
+
+        query.empty? ? path : "#{path}?#{query}"
       end
 
       def self.suspicious_method?(method)

--- a/test/rails/e2e/rails7.2_generic/app/controllers/errors_controller.rb
+++ b/test/rails/e2e/rails7.2_generic/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ErrorsController < ApplicationController
+  # Custom 404 page for test/e2e/attack_wave_test.rb.
+  def not_found
+    render plain: "Not Found", status: :not_found
+  end
+end

--- a/test/rails/e2e/rails7.2_generic/config/application.rb
+++ b/test/rails/e2e/rails7.2_generic/config/application.rb
@@ -43,5 +43,8 @@ module SampleApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Enable custom 404 page for test/e2e/attack_wave_test.rb.
+    config.exceptions_app = routes
   end
 end

--- a/test/rails/e2e/rails7.2_generic/config/environments/test.rb
+++ b/test/rails/e2e/rails7.2_generic/config/environments/test.rb
@@ -20,8 +20,10 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.headers = {"Cache-Control" => "public, max-age=#{1.hour.to_i}"}
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local = true
+  # Enable custom 404 page for test/e2e/attack_wave_test.rb.
+  config.consider_all_requests_local = false
+
+  # Disable caching.
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/test/rails/e2e/rails7.2_generic/config/initializers/zen.rb
+++ b/test/rails/e2e/rails7.2_generic/config/initializers/zen.rb
@@ -6,4 +6,5 @@ if Rails.application.config.respond_to?(:zen)
   zen.worker_process_polling_jitter = 0
   zen.worker_process_heartbeat_interval = 1
   zen.realtime_settings_updates_enabled = true
+  zen.attack_wave_threshold = 1
 end

--- a/test/rails/e2e/rails7.2_generic/config/routes.rb
+++ b/test/rails/e2e/rails7.2_generic/config/routes.rb
@@ -17,4 +17,7 @@ Rails.application.routes.draw do
   get "test/outbound_connection" => "outbound_connection#show"
   get "test/path_traversal" => "path_traversal#show"
   get "test/httpx" => "httpx#show"
+
+  # Enable custom 404 page for test/e2e/attack_wave_test.rb.
+  get "/404" => "errors#not_found"
 end

--- a/test/rails/e2e/rails7.2_generic/test/e2e/attack_wave_test.rb
+++ b/test/rails/e2e/rails7.2_generic/test/e2e/attack_wave_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AttackWaveTest < ActiveSupport::TestCase
+  include RailsServerHelpers
+  include MockServerHelpers
+
+  test "records the real scanned path when a custom 404 controller rewrites PATH_INFO" do
+    client_ip = random_client_ip
+
+    response = rails_get("/wp-config.php", headers: {"X-Forwarded-For" => client_ip})
+    assert_equal "404", response.code
+
+    event = poll_until(timeout: 10) do
+      received_events(type: "detected_attack_wave").find { |e| e.dig("request", "ipAddress") == client_ip }
+    end
+
+    samples = JSON.parse(event.dig("attack", "metadata", "samples"))
+    urls = samples.map { |sample| sample["url"] }
+
+    assert_includes urls, "/wp-config.php",
+      "expected the attack wave sample to record the original path"
+    assert_not_includes urls, "/404",
+      "expected the attack wave sample not to record the rewritten path"
+  end
+
+  private
+
+  def random_client_ip
+    "10.#{rand(1..254)}.#{rand(1..254)}.#{rand(1..254)}"
+  end
+end

--- a/test/rails/e2e/rails7.2_generic/test/test_helper.rb
+++ b/test/rails/e2e/rails7.2_generic/test/test_helper.rb
@@ -45,9 +45,12 @@ module RailsServerHelpers
   RAILS_SERVER_URI = ENV.fetch("RAILS_SERVER_URI", "http://127.0.0.1:3000")
 
   # @param path [String] path and query string to request
+  # @param headers [Hash<String, String>] extra request headers
   # @return [Net::HTTPResponse]
-  def rails_get(path)
-    Net::HTTP.get_response(URI("#{RAILS_SERVER_URI}#{path}"))
+  def rails_get(path, headers: {})
+    uri = URI("#{RAILS_SERVER_URI}#{path}")
+    request = Net::HTTP::Get.new(uri, headers)
+    Net::HTTP.start(uri.host, uri.port) { |http| http.request(request) }
   end
 end
 


### PR DESCRIPTION
This change fixes the attack wave detector missing requests when an application sets a custom `config.exceptions_app`. Rails rewrites `PATH_INFO` to `/<status>` before invoking the custom error controller, while preserving the original path in `env["action_dispatch.original_path"]`. If Rails has rewritten the path, the attack wave detector now uses the original path that Rails preserved.