### PR TITLE
Improve attack wave support for multi-process

### DIFF
--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -249,6 +249,35 @@ module Aikido
       @attack_wave_detector ||= AttackWave::Detector.new
     end
 
+    # @param context [Aikido::Zen::Context]
+    # @param status_code [Integer, nil]
+    # @return [Boolean]
+    def self.attack_wave?(context, status_code = nil)
+      worker_process_client = @worker_process_client
+      return attack_wave_detector.attack_wave?(context, status_code) unless worker_process_client
+
+      client_ip = context.request.client_ip
+      return false unless client_ip
+
+      return false unless AttackWave::Helpers.web_scanner?(context, status_code)
+
+      sample = context.request.then { |r| AttackWave::Sample.new(verb: r.request_method, path: r.fullpath) }
+
+      begin
+        attack, samples = worker_process_client.record_attack_wave(client_ip, sample)
+        attack_wave_detector.samples[client_ip] = samples if attack
+        attack
+      rescue
+        attack_wave_detector.record(client_ip, sample)
+      end
+    end
+
+    # @param client_ip [String]
+    # @return [Array<Aikido::Zen::AttackWave::Sample>]
+    def self.attack_wave_samples(client_ip)
+      attack_wave_detector.samples[client_ip].to_a
+    end
+
     # @return [Aikido::Zen::IDOR::Protector]
     def self.idor_protector
       @idor_protector ||= IDOR::Protector.new

--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -30,14 +30,22 @@ module Aikido::Zen
 
         return false unless AttackWave::Helpers.web_scanner?(context, status_code)
 
+        sample = context.request.then do |request|
+          Sample.new(verb: request.request_method, path: request.fullpath)
+        end
+
+        record(client_ip, sample)
+      end
+
+      # @param client_ip [String]
+      # @param sample [Aikido::Zen::AttackWave::Sample]
+      # @return [Boolean]
+      def record(client_ip, sample)
+        return false if @event_times[client_ip]
+
         request_count = @request_counts[client_ip] += 1
 
-        context.request.then do |request|
-          @samples[client_ip] <<= Sample.new(
-            verb: request.request_method,
-            path: request.fullpath
-          )
-        end
+        @samples[client_ip] <<= sample
 
         return false if request_count < @config.attack_wave_threshold
 
@@ -117,6 +125,10 @@ module Aikido::Zen
     end
 
     class Sample
+      def self.from_json(data)
+        new(verb: data["method"], path: data["url"])
+      end
+
       # @return [String]
       attr_reader :verb
 

--- a/lib/aikido/zen/ipc/ipc.rb
+++ b/lib/aikido/zen/ipc/ipc.rb
@@ -25,6 +25,7 @@ module Aikido
       CONNECT_TIMEOUT = 2.0
       HANDSHAKE_TIMEOUT = 3.0
       READ_TIMEOUT = 5.0
+      READ_ATTACK_WAVE_TIMEOUT = 1.0
       WRITE_TIMEOUT = 5.0
 
       RECONNECT_DELAY = 1.0

--- a/lib/aikido/zen/middleware/attack_wave_protector.rb
+++ b/lib/aikido/zen/middleware/attack_wave_protector.rb
@@ -28,7 +28,7 @@ module Aikido
 
           return false if @settings.bypassed_ips.include?(request.client_ip)
 
-          @zen.attack_wave_detector.attack_wave?(context, status_code)
+          @zen.attack_wave?(context, status_code)
         end
 
         # @api private
@@ -43,7 +43,7 @@ module Aikido
               source: context.request.framework
             )
 
-            samples = @zen.attack_wave_detector.samples[client_ip].to_a
+            samples = @zen.attack_wave_samples(client_ip)
 
             attack = Aikido::Zen::AttackWave::Attack.new(
               samples: samples,

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -68,6 +68,21 @@ module Aikido::Zen::WorkerProcess
         raise
       end
 
+      # @return [Array(Boolean, Array<Aikido::Zen::AttackWave::Sample>)]
+      def record_attack_wave(client_ip, sample)
+        result = @rpc_client.invoke(
+          "record_attack_wave", Aikido::Zen::IPC::READ_TIMEOUT,
+          client_ip, sample.verb, sample.path
+        )
+
+        samples = result["samples"].map { |data| Aikido::Zen::AttackWave::Sample.from_json(data) }
+
+        [result["attack"], samples]
+      rescue => err
+        @config.logger.error("Forked worker process #{Process.pid}: failed to record attack wave hit with parent: #{err.message}")
+        raise
+      end
+
       private
 
       def updated_settings

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -70,8 +70,9 @@ module Aikido::Zen::WorkerProcess
 
       # @return [Array(Boolean, Array<Aikido::Zen::AttackWave::Sample>)]
       def record_attack_wave(client_ip, sample)
+        # An attacker can trigger this at will, so we'd rather serve the app.
         result = @rpc_client.invoke(
-          "record_attack_wave", Aikido::Zen::IPC::READ_TIMEOUT,
+          "record_attack_wave", Aikido::Zen::IPC::READ_ATTACK_WAVE_TIMEOUT,
           client_ip, sample.verb, sample.path
         )
 

--- a/lib/aikido/zen/worker_process/agent/server.rb
+++ b/lib/aikido/zen/worker_process/agent/server.rb
@@ -25,6 +25,10 @@ module Aikido::Zen::WorkerProcess
           result = calculate_rate_limits(route_data, ip, actor_data)
           respond.call(result&.as_json)
         end
+
+        @rpc_server.handle("record_attack_wave") do |respond, client_ip, verb, path|
+          respond.call(record_attack_wave(client_ip, verb, path))
+        end
       end
 
       def host
@@ -91,6 +95,17 @@ module Aikido::Zen::WorkerProcess
         actor = Aikido::Zen::Actor.from_json(actor_data) if actor_data
         route = Aikido::Zen::Route.from_json(route_data)
         Aikido::Zen.rate_limiter.calculate_rate_limits(RequestKind.new(route, nil, ip, actor))
+      end
+
+      # @return [Hash]
+      def record_attack_wave(client_ip, verb, path)
+        sample = Aikido::Zen::AttackWave::Sample.new(verb: verb, path: path)
+        detector = Aikido::Zen.attack_wave_detector
+
+        attack = detector.record(client_ip, sample)
+        samples = attack ? detector.samples[client_ip].to_a.map(&:as_json) : []
+
+        {"attack" => attack, "samples" => samples}
       end
     end
   end

--- a/test/aikido/zen/attack_wave_test.rb
+++ b/test/aikido/zen/attack_wave_test.rb
@@ -222,5 +222,16 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
 
       assert_equal expected, samples.as_json
     end
+
+    test "#record shares state with #attack_wave? so a delegated recording is reflected locally" do
+      detector = build_detector
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      refute detector.record("1.2.3.4", sample)
+      refute detector.record("1.2.3.4", sample)
+      assert detector.record("1.2.3.4", sample)
+
+      refute_attack_wave_for("/.config", detector: detector)
+    end
   end
 end

--- a/test/aikido/zen/middleware/attack_wave_protector_test.rb
+++ b/test/aikido/zen/middleware/attack_wave_protector_test.rb
@@ -60,7 +60,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     context = build_context_for("/.config", DEFAULT_ENV)
 
     zen.expect :current_context, context
-    zen.expect :attack_wave_detector, Aikido::Zen.attack_wave_detector
+    zen.expect(:attack_wave?, false) { |ctx, status_code| ctx == context && status_code == 200 }
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -68,7 +68,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
-    zen.expect :attack_wave_detector, Aikido::Zen.attack_wave_detector
+    zen.expect(:attack_wave?, false) { |ctx, status_code| ctx == context && status_code == 200 }
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -76,9 +76,11 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
-    2.times { zen.expect :attack_wave_detector, Aikido::Zen.attack_wave_detector }
+    zen.expect(:attack_wave?, true) { |ctx, status_code| ctx == context && status_code == 200 }
 
     attack_wave = build_attack_wave(context)
+
+    zen.expect(:attack_wave_samples, attack_wave.attack.samples) { |ip| ip == context.request.client_ip }
 
     zen.expect(:track_attack_wave, nil) do |arg|
       arg.is_a?(Aikido::Zen::Events::AttackWave) &&

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -271,6 +271,41 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "#record_attack_wave returns false and no samples when the parent says it isn't an attack wave yet" do
+    result_data = {"attack" => false, "samples" => []}
+
+    build_agent("updated_settings" => {}, "record_attack_wave" => result_data) do |agent|
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      assert_equal [false, []], agent.record_attack_wave("1.2.3.4", sample)
+    end
+  end
+
+  test "#record_attack_wave parses the samples returned alongside a positive verdict" do
+    result_data = {"attack" => true, "samples" => [{"method" => "GET", "url" => "/.config"}]}
+
+    build_agent("updated_settings" => {}, "record_attack_wave" => result_data) do |agent|
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      attack, samples = agent.record_attack_wave("1.2.3.4", sample)
+
+      assert attack
+      assert_equal [Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")], samples
+    end
+  end
+
+  test "#record_attack_wave logs and re-raises when the RPC call raises" do
+    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      client.stub(:invoke, ->(*) { raise "RPC error" }) do
+        err = assert_raises(RuntimeError) { agent.record_attack_wave("1.2.3.4", sample) }
+        assert_equal "RPC error", err.message
+        assert_logged :error, /failed to record attack wave hit with parent/i
+      end
+    end
+  end
+
   test "the scheduled keepalive task pings the parent" do
     build_agent("updated_settings" => {}) do |agent, worker, collector, client, keepalive_worker|
       assert_nothing_raised { keepalive_worker.jobs[0].task.call }

--- a/test/aikido/zen/worker_process/agent/server_test.rb
+++ b/test/aikido/zen/worker_process/agent/server_test.rb
@@ -326,4 +326,15 @@ class Aikido::Zen::WorkerProcess::Agent::ServerTest < ActiveSupport::TestCase
 
     assert_nil received_actor
   end
+
+  test "#record_attack_wave records the hit against the shared detector, and returns the samples once it crosses the threshold" do
+    Aikido::Zen.config.attack_wave_threshold = 2
+
+    refute @server.record_attack_wave("1.2.3.4", "GET", "/.config")["attack"]
+
+    result = @server.record_attack_wave("1.2.3.4", "GET", "/.config")
+
+    assert result["attack"]
+    assert_equal [{"method" => "GET", "url" => "/.config"}], result["samples"]
+  end
 end

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -176,4 +176,65 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     assert_equal :local_result, result
     assert_mock rate_limiter_mock
   end
+
+  def attack_wave_context_for(path, env = {})
+    Aikido::Zen::Context.from_rack_env(Rack::MockRequest.env_for(path, env))
+  end
+
+  test ".attack_wave? delegates to the local detector when there is no detached agent" do
+    context = attack_wave_context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    mock = Minitest::Mock.new
+    mock.expect(:attack_wave?, true, [context, nil])
+
+    result = Aikido::Zen.stub(:attack_wave_detector, mock) do
+      Aikido::Zen.attack_wave?(context)
+    end
+
+    assert result
+    assert_mock mock
+  end
+
+  test ".attack_wave? never calls the detached agent when the request isn't suspicious" do
+    context = attack_wave_context_for("/safe", "REMOTE_ADDR" => "1.2.3.4")
+
+    client = Class.new do
+      attr_reader :called
+
+      def record_attack_wave(*)
+        @called = true
+      end
+    end.new
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, client)
+
+    refute Aikido::Zen.attack_wave?(context)
+    refute client.called
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave? falls back to the local detector when the worker process client raises" do
+    context = attack_wave_context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    failing_client = Object.new
+
+    def failing_client.record_attack_wave(client_ip, sample)
+      raise "RPC error"
+    end
+
+    detector_mock = Minitest::Mock.new
+    detector_mock.expect(:record, true, ["1.2.3.4", Object])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
+
+    result = Aikido::Zen.stub(:attack_wave_detector, detector_mock) do
+      Aikido::Zen.attack_wave?(context)
+    end
+
+    assert result
+    assert_mock detector_mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
 end

--- a/test/rails/e2e/rails7.2_generic/test/e2e/worker_process_test.rb
+++ b/test/rails/e2e/rails7.2_generic/test/e2e/worker_process_test.rb
@@ -122,10 +122,38 @@ class WorkerProcessTest < ActiveSupport::TestCase
     assert_equal "429", responses[2].code
   end
 
+  test "worker process reports one attack wave for hits shared across worker processes" do
+    client_ip = "203.0.113.#{rand(2..254)}"
+
+    baseline = received_events(type: "detected_attack_wave").length
+
+    15.times { |i| trigger_attack_wave_hit(client_ip, i) }
+
+    fresh = wait_for_event(type: "detected_attack_wave", after_index: baseline, timeout: 5)
+    assert_equal 1, fresh.length, "Expected exactly 1 detected_attack_wave event, got #{fresh.length}"
+
+    samples = JSON.parse(fresh.first.dig("attack", "metadata", "samples"))
+    expected_samples = 15.times.map { |i| {"method" => "GET", "url" => "/test/worker_process?i=#{i}&q=SELECT+*+FROM+users"} }
+    assert_equal expected_samples, samples
+
+    5.times { |i| trigger_attack_wave_hit(client_ip, 15 + i) }
+    sleep 1.5
+
+    assert_equal 1, received_events(type: "detected_attack_wave")[baseline..].length
+  end
+
   private
 
   def trigger_attack
     rails_get("/test/path_traversal?path=../../../../etc/passwd")
+  end
+
+  def trigger_attack_wave_hit(client_ip, index)
+    uri = URI("#{RailsServerHelpers::RAILS_SERVER_URI}/test/worker_process?i=#{index}&q=SELECT+*+FROM+users")
+    request = Net::HTTP::Get.new(uri)
+    request["X-Forwarded-For"] = client_ip
+
+    Net::HTTP.start(uri.host, uri.port) { |http| http.request(request) }
   end
 
   # Polls until a qualifying response has been seen from at least +count+


### PR DESCRIPTION
When running with multiple puma workers, the attack wave suspicious request count is stored per worker. Similarly to reporting heartbeats with the request stats, we should count stats across workers and merge them. This ensures that 15 reqs to multiple workers triggers one attack wave.