### PR TITLE
Centralize attack wave detection state

### DIFF
--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -268,6 +268,13 @@ module Aikido
     # triggering an attack wave is crossed. If the threshold is crossed,
     # the client IP is flagged as having just triggered an attack wave.
     #
+    # In multiprocess deployments, on RPC failure, the worker process
+    # records against its local detector.
+    #
+    # If RPC failures are intermittent, it is possible that an attack
+    # wave may be missed or duplicated, because state is split between
+    # the global and local detectors.
+    #
     # @param client_ip [String]
     # @param sample [Aikido::Zen::AttackWave::Sample]
     # @return [Boolean]

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -249,24 +249,24 @@ module Aikido
       @attack_wave_detector ||= AttackWave::Detector.new
     end
 
-    # Classifies the current request and returns whether the threshold for
-    # triggering an attack wave is crossed.
+    # Classifies the current request and, if it is classified as suspicious,
+    # records a sample against the attack wave detector.
     #
     # @param context [Aikido::Zen::Context]
     # @param status_code [Integer, nil]
-    # @return [Boolean]
-    def self.attack_wave?(context, status_code = nil)
+    # @return [Array<Aikido::Zen::AttackWave::Sample>, nil]
+    def self.detect_attack_wave(context, status_code = nil)
       client_ip = context.request.client_ip
-      return false unless client_ip
+      return nil unless client_ip
 
-      return false unless AttackWave::Helpers.web_scanner?(context, status_code)
+      return nil unless AttackWave::Helpers.web_scanner?(context, status_code)
 
       record_attack_wave(client_ip, AttackWave::Helpers.sample_for(context))
     end
 
-    # Records a suspicious sample and returns whether the threshold for
-    # triggering an attack wave is crossed. If the threshold is crossed,
-    # the client IP is flagged as having just triggered an attack wave.
+    # Records a suspicious sample and, if the threshold for triggering
+    # an attack wave has been crossed, flags the client IP as having
+    # just triggered an attack wave.
     #
     # In multiprocess deployments, on RPC failure, the worker process
     # records against its local detector.
@@ -277,7 +277,7 @@ module Aikido
     #
     # @param client_ip [String]
     # @param sample [Aikido::Zen::AttackWave::Sample]
-    # @return [Boolean]
+    # @return [Array<Aikido::Zen::AttackWave::Sample>, nil]
     def self.record_attack_wave(client_ip, sample)
       worker_process_client = @worker_process_client
 
@@ -289,25 +289,6 @@ module Aikido
         end
       else
         attack_wave_detector.record(client_ip, sample)
-      end
-    end
-
-    # Returns any samples collected for the client IP as part of the
-    # current attack wave.
-    #
-    # @param client_ip [String]
-    # @return [Array<Aikido::Zen::AttackWave::Sample>]
-    def self.attack_wave_samples(client_ip)
-      worker_process_client = @worker_process_client
-
-      if worker_process_client
-        begin
-          worker_process_client.attack_wave_samples(client_ip)
-        rescue
-          attack_wave_detector.samples[client_ip].to_a
-        end
-      else
-        attack_wave_detector.samples[client_ip].to_a
       end
     end
 

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -259,30 +259,9 @@ module Aikido
       client_ip = context.request.client_ip
       return false unless client_ip
 
-      return false if attack_wave_flagged?(client_ip)
-
       return false unless AttackWave::Helpers.web_scanner?(context, status_code)
 
       record_attack_wave(client_ip, AttackWave::Helpers.sample_for(context))
-    end
-
-    # Whether the client IP is within the cooldown period after triggering
-    # an attack wave.
-    #
-    # @param client_ip [String]
-    # @return [Boolean]
-    def self.attack_wave_flagged?(client_ip)
-      worker_process_client = @worker_process_client
-
-      if worker_process_client
-        begin
-          worker_process_client.attack_wave_flagged?(client_ip)
-        rescue
-          attack_wave_detector.flagged?(client_ip)
-        end
-      else
-        attack_wave_detector.flagged?(client_ip)
-      end
     end
 
     # Records a suspicious sample and returns whether the threshold for

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -249,6 +249,82 @@ module Aikido
       @attack_wave_detector ||= AttackWave::Detector.new
     end
 
+    # Classifies the current request and returns whether the threshold for
+    # triggering an attack wave is crossed.
+    #
+    # @param context [Aikido::Zen::Context]
+    # @param status_code [Integer, nil]
+    # @return [Boolean]
+    def self.attack_wave?(context, status_code = nil)
+      client_ip = context.request.client_ip
+      return false unless client_ip
+
+      return false if attack_wave_flagged?(client_ip)
+
+      return false unless AttackWave::Helpers.web_scanner?(context, status_code)
+
+      record_attack_wave(client_ip, AttackWave::Helpers.sample_for(context))
+    end
+
+    # Whether the client IP is within the cooldown period after triggering
+    # an attack wave.
+    #
+    # @param client_ip [String]
+    # @return [Boolean]
+    def self.attack_wave_flagged?(client_ip)
+      worker_process_client = @worker_process_client
+
+      if worker_process_client
+        begin
+          worker_process_client.attack_wave_flagged?(client_ip)
+        rescue
+          attack_wave_detector.flagged?(client_ip)
+        end
+      else
+        attack_wave_detector.flagged?(client_ip)
+      end
+    end
+
+    # Records a suspicious sample and returns whether the threshold for
+    # triggering an attack wave is crossed. If the threshold is crossed,
+    # the client IP is flagged as having just triggered an attack wave.
+    #
+    # @param client_ip [String]
+    # @param sample [Aikido::Zen::AttackWave::Sample]
+    # @return [Boolean]
+    def self.record_attack_wave(client_ip, sample)
+      worker_process_client = @worker_process_client
+
+      if worker_process_client
+        begin
+          worker_process_client.record_attack_wave(client_ip, sample)
+        rescue
+          attack_wave_detector.record(client_ip, sample)
+        end
+      else
+        attack_wave_detector.record(client_ip, sample)
+      end
+    end
+
+    # Returns any samples collected for the client IP as part of the
+    # current attack wave.
+    #
+    # @param client_ip [String]
+    # @return [Array<Aikido::Zen::AttackWave::Sample>]
+    def self.attack_wave_samples(client_ip)
+      worker_process_client = @worker_process_client
+
+      if worker_process_client
+        begin
+          worker_process_client.attack_wave_samples(client_ip)
+        rescue
+          attack_wave_detector.samples[client_ip].to_a
+        end
+      else
+        attack_wave_detector.samples[client_ip].to_a
+      end
+    end
+
     # @return [Aikido::Zen::IDOR::Protector]
     def self.idor_protector
       @idor_protector ||= IDOR::Protector.new

--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -52,29 +52,29 @@ module Aikido::Zen
         @event_times[client_ip] = Time.now.utc
       end
 
-      # Records a suspicious sample and returns whether the threshold for
-      # triggering an attack wave is crossed. If the threshold is crossed,
-      # the client IP is flagged as having just triggered an attack wave.
+      # Records a suspicious sample and, if it crosses the threshold for
+      # triggering an attack wave, flags the client IP as having just
+      # triggered an attack wave.
       #
       # This method is synchronized to prevent concurrent calls for the
       # same client IP from crossing the threshold in the same instant.
       #
       # @param client_ip [String]
       # @param sample [Aikido::Zen::AttackWave::Sample]
-      # @return [Boolean]
+      # @return [Array<Aikido::Zen::AttackWave::Sample>, nil]
       def record(client_ip, sample)
         @mutex.synchronize do
-          return false if flagged?(client_ip)
+          return nil if flagged?(client_ip)
 
           request_count = @request_counts[client_ip] += 1
 
           @samples[client_ip] <<= sample
 
-          return false if request_count < @config.attack_wave_threshold
+          return nil if request_count < @config.attack_wave_threshold
 
           flag!(client_ip)
 
-          true
+          @samples[client_ip].to_a
         end
       end
     end

--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -5,12 +5,19 @@ require_relative "attack_wave/helpers"
 
 module Aikido::Zen
   module AttackWave
+    # Tracks per-client-IP attack wave state.
+    #
+    # In multiprocess deployments, the main process has a single instance
+    # that may be accessed concurrently from each forked worker process's
+    # Aikido::Zen::RPC::Server connection thread.
     class Detector
       # @return [Aikido::Zen::CappedSet]
       attr_reader :samples
 
       def initialize(config: Aikido::Zen.config, clock: nil)
         @config = config
+
+        @mutex = Mutex.new
 
         @event_times = Cache.new(@config.attack_wave_max_cache_entries, ttl: @config.attack_wave_min_time_between_events, clock: clock)
 
@@ -43,21 +50,26 @@ module Aikido::Zen
       # triggering an attack wave is crossed. If the threshold is crossed,
       # the client IP is flagged as having just triggered an attack wave.
       #
+      # This method is synchronized to prevent concurrent calls for the
+      # same client IP from crossing the threshold in the same instant.
+      #
       # @param client_ip [String]
       # @param sample [Aikido::Zen::AttackWave::Sample]
       # @return [Boolean]
       def record(client_ip, sample)
-        return false if flagged?(client_ip)
+        @mutex.synchronize do
+          return false if flagged?(client_ip)
 
-        request_count = @request_counts[client_ip] += 1
+          request_count = @request_counts[client_ip] += 1
 
-        @samples[client_ip] <<= sample
+          @samples[client_ip] <<= sample
 
-        return false if request_count < @config.attack_wave_threshold
+          return false if request_count < @config.attack_wave_threshold
 
-        flag!(client_ip)
+          flag!(client_ip)
 
-        true
+          true
+        end
       end
     end
 

--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -28,6 +28,9 @@ module Aikido::Zen
         end
       end
 
+      # @api private
+      # @note Visible for testing.
+      #
       # Whether the client IP is within the cooldown period after triggering
       # an attack wave.
       #
@@ -37,6 +40,9 @@ module Aikido::Zen
         !!@event_times[client_ip]
       end
 
+      # @api private
+      # @note Visible for testing.
+      #
       # Flags the client IP as having triggered an attack wave for the
       # cooldown period.
       #

--- a/lib/aikido/zen/attack_wave.rb
+++ b/lib/aikido/zen/attack_wave.rb
@@ -21,27 +21,41 @@ module Aikido::Zen
         end
       end
 
-      def attack_wave?(context, status_code = nil)
-        client_ip = context.request.client_ip
+      # Whether the client IP is within the cooldown period after triggering
+      # an attack wave.
+      #
+      # @param client_ip [String]
+      # @return [Boolean]
+      def flagged?(client_ip)
+        !!@event_times[client_ip]
+      end
 
-        return false unless client_ip
+      # Flags the client IP as having triggered an attack wave for the
+      # cooldown period.
+      #
+      # @param client_ip [String]
+      # @return [void]
+      def flag!(client_ip)
+        @event_times[client_ip] = Time.now.utc
+      end
 
-        return false if @event_times[client_ip]
-
-        return false unless AttackWave::Helpers.web_scanner?(context, status_code)
+      # Records a suspicious sample and returns whether the threshold for
+      # triggering an attack wave is crossed. If the threshold is crossed,
+      # the client IP is flagged as having just triggered an attack wave.
+      #
+      # @param client_ip [String]
+      # @param sample [Aikido::Zen::AttackWave::Sample]
+      # @return [Boolean]
+      def record(client_ip, sample)
+        return false if flagged?(client_ip)
 
         request_count = @request_counts[client_ip] += 1
 
-        context.request.then do |request|
-          @samples[client_ip] <<= Sample.new(
-            verb: request.request_method,
-            path: AttackWave::Helpers.original_fullpath(request)
-          )
-        end
+        @samples[client_ip] <<= sample
 
         return false if request_count < @config.attack_wave_threshold
 
-        @event_times[client_ip] = Time.now.utc
+        flag!(client_ip)
 
         true
       end
@@ -117,6 +131,10 @@ module Aikido::Zen
     end
 
     class Sample
+      def self.from_json(data)
+        new(verb: data["method"], path: data["url"])
+      end
+
       # @return [String]
       attr_reader :verb
 

--- a/lib/aikido/zen/attack_wave/helpers.rb
+++ b/lib/aikido/zen/attack_wave/helpers.rb
@@ -13,6 +13,16 @@ module Aikido::Zen
         false
       end
 
+      # Builds the sample for a request that has been classified as suspicious.
+      #
+      # @param context [Aikido::Zen::Context]
+      # @return [Aikido::Zen::AttackWave::Sample]
+      def self.sample_for(context)
+        request = context.request
+
+        Sample.new(verb: request.request_method, path: original_fullpath(request))
+      end
+
       def self.suspicious_request?(context, status_code)
         request = context.request
 

--- a/lib/aikido/zen/cache.rb
+++ b/lib/aikido/zen/cache.rb
@@ -5,7 +5,7 @@ module Aikido::Zen
     extend Forwardable
 
     # @api private
-    # Visible for testing.
+    # @note Visible for testing.
     def_delegators :@data,
       :size, :empty?
 
@@ -54,13 +54,13 @@ module Aikido::Zen
     end
 
     # @api private
-    # Visible for testing.
+    # @note Visible for testing.
     def to_a
       @data.map { |key, entry| [key, entry.value] }
     end
 
     # @api private
-    # Visible for testing.
+    # @note Visible for testing.
     def to_h
       to_a.to_h
     end

--- a/lib/aikido/zen/collector.rb
+++ b/lib/aikido/zen/collector.rb
@@ -210,7 +210,6 @@ module Aikido::Zen
     end
 
     # @api private
-    #
     # @note Visible for testing.
     def stats
       handle
@@ -218,7 +217,6 @@ module Aikido::Zen
     end
 
     # @api private
-    #
     # @note Visible for testing.
     def users
       handle
@@ -226,7 +224,6 @@ module Aikido::Zen
     end
 
     # @api private
-    #
     # @note Visible for testing.
     def hosts
       handle
@@ -234,7 +231,6 @@ module Aikido::Zen
     end
 
     # @api private
-    #
     # @note Visible for testing.
     def routes
       handle
@@ -242,7 +238,6 @@ module Aikido::Zen
     end
 
     # @api private
-    #
     # @note Visible for testing.
     def middleware_installed?
       @middleware_installed.true?

--- a/lib/aikido/zen/collector/routes.rb
+++ b/lib/aikido/zen/collector/routes.rb
@@ -8,7 +8,7 @@ module Aikido::Zen
   # Keeps track of the visited routes.
   class Collector::Routes
     # @api private
-    # Visible for testing.
+    # @note Visible for testing.
     attr_reader :visits
 
     def initialize(config = Aikido::Zen.config)
@@ -35,7 +35,7 @@ module Aikido::Zen
     end
 
     # @api private
-    # Visible for testing.
+    # @note Visible for testing.
     def [](route)
       @visits[route]
     end

--- a/lib/aikido/zen/idor/protector.rb
+++ b/lib/aikido/zen/idor/protector.rb
@@ -7,7 +7,7 @@ module Aikido::Zen
 
     class Protector
       # @api private
-      # Visible for testing.
+      # @note Visible for testing.
       attr_accessor :cache
 
       def initialize(config: Aikido::Zen.config)

--- a/lib/aikido/zen/middleware/attack_wave_protector.rb
+++ b/lib/aikido/zen/middleware/attack_wave_protector.rb
@@ -28,7 +28,7 @@ module Aikido
 
           return false if @settings.bypassed_ips.include?(request.client_ip)
 
-          @zen.attack_wave_detector.attack_wave?(context, status_code)
+          @zen.attack_wave?(context, status_code)
         end
 
         # @api private
@@ -43,7 +43,7 @@ module Aikido
               source: context.request.framework
             )
 
-            samples = @zen.attack_wave_detector.samples[client_ip].to_a
+            samples = @zen.attack_wave_samples(client_ip)
 
             attack = Aikido::Zen::AttackWave::Attack.new(
               samples: samples,

--- a/lib/aikido/zen/middleware/attack_wave_protector.rb
+++ b/lib/aikido/zen/middleware/attack_wave_protector.rb
@@ -21,7 +21,7 @@ module Aikido
         end
 
         # @api private
-        # Visible for testing.
+        # @note Visible for testing.
         def attack_wave?(context, status_code = nil)
           request = context.request
           return false if request.nil?
@@ -32,7 +32,7 @@ module Aikido
         end
 
         # @api private
-        # Visible for testing.
+        # @note Visible for testing.
         def protect(context, status_code = nil)
           if attack_wave?(context, status_code)
             client_ip = context.request.client_ip

--- a/lib/aikido/zen/middleware/attack_wave_protector.rb
+++ b/lib/aikido/zen/middleware/attack_wave_protector.rb
@@ -22,42 +22,45 @@ module Aikido
 
         # @api private
         # @note Visible for testing.
-        def attack_wave?(context, status_code = nil)
+        #
+        # @param context [Aikido::Zen::Context]
+        # @param status_code [Integer, nil]
+        # @return [Array<Aikido::Zen::AttackWave::Sample>, nil]
+        def detect_attack_wave(context, status_code = nil)
           request = context.request
-          return false if request.nil?
+          return nil if request.nil?
 
-          return false if @settings.bypassed_ips.include?(request.client_ip)
+          return nil if @settings.bypassed_ips.include?(request.client_ip)
 
-          @zen.attack_wave?(context, status_code)
+          @zen.detect_attack_wave(context, status_code)
         end
 
         # @api private
         # @note Visible for testing.
         def protect(context, status_code = nil)
-          if attack_wave?(context, status_code)
-            client_ip = context.request.client_ip
+          samples = detect_attack_wave(context, status_code)
+          return unless samples
 
-            request = Aikido::Zen::AttackWave::Request.new(
-              ip_address: client_ip,
-              user_agent: context.request.user_agent,
-              source: context.request.framework
-            )
+          client_ip = context.request.client_ip
 
-            samples = @zen.attack_wave_samples(client_ip)
+          request = Aikido::Zen::AttackWave::Request.new(
+            ip_address: client_ip,
+            user_agent: context.request.user_agent,
+            source: context.request.framework
+          )
 
-            attack = Aikido::Zen::AttackWave::Attack.new(
-              samples: samples,
-              user: context.request.actor
-            )
+          attack = Aikido::Zen::AttackWave::Attack.new(
+            samples: samples,
+            user: context.request.actor
+          )
 
-            attack_wave = Aikido::Zen::Events::AttackWave.new(
-              request: request,
-              attack: attack
-            )
+          attack_wave = Aikido::Zen::Events::AttackWave.new(
+            request: request,
+            attack: attack
+          )
 
-            @zen.track_attack_wave(attack_wave)
-            @zen.agent.report(attack_wave)
-          end
+          @zen.track_attack_wave(attack_wave)
+          @zen.agent.report(attack_wave)
         end
       end
     end

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -75,24 +75,15 @@ module Aikido::Zen::WorkerProcess
 
       # @param client_ip [String]
       # @param sample [Aikido::Zen::AttackWave::Sample]
-      # @return [Boolean]
+      # @return [Array<Aikido::Zen::AttackWave::Sample>, nil]
       def record_attack_wave(client_ip, sample)
-        @rpc_client.invoke(
+        result = @rpc_client.invoke(
           "record_attack_wave", ATTACK_WAVE_TIMEOUT,
           client_ip, sample.verb, sample.path
         )
+        result&.map { |data| Aikido::Zen::AttackWave::Sample.from_json(data) }
       rescue => err
         @config.logger.error("Forked worker process #{Process.pid}: failed to record attack wave sample with parent: #{err.message}")
-        raise
-      end
-
-      # @param client_ip [String]
-      # @return [Array<Aikido::Zen::AttackWave::Sample>]
-      def attack_wave_samples(client_ip)
-        result = @rpc_client.invoke("attack_wave_samples", ATTACK_WAVE_TIMEOUT, client_ip)
-        result.map { |data| Aikido::Zen::AttackWave::Sample.from_json(data) }
-      rescue => err
-        @config.logger.error("Forked worker process #{Process.pid}: failed to get attack wave samples from parent: #{err.message}")
         raise
       end
 

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -74,15 +74,6 @@ module Aikido::Zen::WorkerProcess
       end
 
       # @param client_ip [String]
-      # @return [Boolean]
-      def attack_wave_flagged?(client_ip)
-        @rpc_client.invoke("attack_wave_flagged?", ATTACK_WAVE_TIMEOUT, client_ip)
-      rescue => err
-        @config.logger.error("Forked worker process #{Process.pid}: failed to check attack wave status with parent: #{err.message}")
-        raise
-      end
-
-      # @param client_ip [String]
       # @param sample [Aikido::Zen::AttackWave::Sample]
       # @return [Boolean]
       def record_attack_wave(client_ip, sample)

--- a/lib/aikido/zen/worker_process/agent/client.rb
+++ b/lib/aikido/zen/worker_process/agent/client.rb
@@ -8,6 +8,11 @@ module Aikido::Zen::WorkerProcess
       # The keepalive interval must be less than the RPC server read timeout.
       KEEPALIVE_INTERVAL = 4
 
+      # This read timeout should be kept short because attackers can trigger
+      # attack wave detection checks at will, to limit how much latency an
+      # attacker can introduce per request.
+      ATTACK_WAVE_TIMEOUT = 1.0
+
       def initialize(
         host,
         port,
@@ -65,6 +70,38 @@ module Aikido::Zen::WorkerProcess
         Aikido::Zen::RateLimiter::Result.from_json(result) if result
       rescue => err
         @config.logger.error("Forked worker process #{Process.pid}: failed to get rate limits from parent: #{err.message}")
+        raise
+      end
+
+      # @param client_ip [String]
+      # @return [Boolean]
+      def attack_wave_flagged?(client_ip)
+        @rpc_client.invoke("attack_wave_flagged?", ATTACK_WAVE_TIMEOUT, client_ip)
+      rescue => err
+        @config.logger.error("Forked worker process #{Process.pid}: failed to check attack wave status with parent: #{err.message}")
+        raise
+      end
+
+      # @param client_ip [String]
+      # @param sample [Aikido::Zen::AttackWave::Sample]
+      # @return [Boolean]
+      def record_attack_wave(client_ip, sample)
+        @rpc_client.invoke(
+          "record_attack_wave", ATTACK_WAVE_TIMEOUT,
+          client_ip, sample.verb, sample.path
+        )
+      rescue => err
+        @config.logger.error("Forked worker process #{Process.pid}: failed to record attack wave sample with parent: #{err.message}")
+        raise
+      end
+
+      # @param client_ip [String]
+      # @return [Array<Aikido::Zen::AttackWave::Sample>]
+      def attack_wave_samples(client_ip)
+        result = @rpc_client.invoke("attack_wave_samples", ATTACK_WAVE_TIMEOUT, client_ip)
+        result.map { |data| Aikido::Zen::AttackWave::Sample.from_json(data) }
+      rescue => err
+        @config.logger.error("Forked worker process #{Process.pid}: failed to get attack wave samples from parent: #{err.message}")
         raise
       end
 

--- a/lib/aikido/zen/worker_process/agent/server.rb
+++ b/lib/aikido/zen/worker_process/agent/server.rb
@@ -30,10 +30,6 @@ module Aikido::Zen::WorkerProcess
         @rpc_server.handle("record_attack_wave") do |respond, client_ip, verb, path|
           respond.call(record_attack_wave(client_ip, verb, path))
         end
-
-        @rpc_server.handle("attack_wave_samples") do |respond, client_ip|
-          respond.call(attack_wave_samples(client_ip))
-        end
       end
 
       def host
@@ -101,15 +97,11 @@ module Aikido::Zen::WorkerProcess
         Aikido::Zen.rate_limiter.calculate_rate_limits(RequestKind.new(route, nil, ip, actor))
       end
 
-      # @return [Boolean]
+      # @return [Array<Hash>, nil]
       def record_attack_wave(client_ip, verb, path)
         sample = Aikido::Zen::AttackWave::Sample.new(verb: verb, path: path)
-        @detector.record(client_ip, sample)
-      end
-
-      # @return [Array<Hash>]
-      def attack_wave_samples(client_ip)
-        @detector.samples[client_ip].to_a.map(&:as_json)
+        samples = @detector.record(client_ip, sample)
+        samples&.map(&:as_json)
       end
     end
   end

--- a/lib/aikido/zen/worker_process/agent/server.rb
+++ b/lib/aikido/zen/worker_process/agent/server.rb
@@ -69,8 +69,7 @@ module Aikido::Zen::WorkerProcess
       end
 
       # @api private
-      #
-      # Visible for testing.
+      # @note Visible for testing.
       RequestKind = Struct.new(:route, :schema, :client_ip, :actor)
 
       def updated_settings(known_config_generation = nil, known_firewall_lists_generation = nil)

--- a/lib/aikido/zen/worker_process/agent/server.rb
+++ b/lib/aikido/zen/worker_process/agent/server.rb
@@ -3,8 +3,9 @@
 module Aikido::Zen::WorkerProcess
   module Agent
     class Server
-      def initialize(config: Aikido::Zen.config)
+      def initialize(config: Aikido::Zen.config, detector: Aikido::Zen.attack_wave_detector)
         @config = config
+        @detector = detector
 
         @rpc_server = Aikido::Zen::RPC::Server.new(Aikido::Zen.secret)
 
@@ -24,6 +25,18 @@ module Aikido::Zen::WorkerProcess
         @rpc_server.handle("calculate_rate_limits") do |respond, route_data, ip, actor_data|
           result = calculate_rate_limits(route_data, ip, actor_data)
           respond.call(result&.as_json)
+        end
+
+        @rpc_server.handle("attack_wave_flagged?") do |respond, client_ip|
+          respond.call(attack_wave_flagged?(client_ip))
+        end
+
+        @rpc_server.handle("record_attack_wave") do |respond, client_ip, verb, path|
+          respond.call(record_attack_wave(client_ip, verb, path))
+        end
+
+        @rpc_server.handle("attack_wave_samples") do |respond, client_ip|
+          respond.call(attack_wave_samples(client_ip))
         end
       end
 
@@ -91,6 +104,22 @@ module Aikido::Zen::WorkerProcess
         actor = Aikido::Zen::Actor.from_json(actor_data) if actor_data
         route = Aikido::Zen::Route.from_json(route_data)
         Aikido::Zen.rate_limiter.calculate_rate_limits(RequestKind.new(route, nil, ip, actor))
+      end
+
+      # @return [Boolean]
+      def attack_wave_flagged?(client_ip)
+        @detector.flagged?(client_ip)
+      end
+
+      # @return [Boolean]
+      def record_attack_wave(client_ip, verb, path)
+        sample = Aikido::Zen::AttackWave::Sample.new(verb: verb, path: path)
+        @detector.record(client_ip, sample)
+      end
+
+      # @return [Array<Hash>]
+      def attack_wave_samples(client_ip)
+        @detector.samples[client_ip].to_a.map(&:as_json)
       end
     end
   end

--- a/lib/aikido/zen/worker_process/agent/server.rb
+++ b/lib/aikido/zen/worker_process/agent/server.rb
@@ -27,10 +27,6 @@ module Aikido::Zen::WorkerProcess
           respond.call(result&.as_json)
         end
 
-        @rpc_server.handle("attack_wave_flagged?") do |respond, client_ip|
-          respond.call(attack_wave_flagged?(client_ip))
-        end
-
         @rpc_server.handle("record_attack_wave") do |respond, client_ip, verb, path|
           respond.call(record_attack_wave(client_ip, verb, path))
         end
@@ -104,11 +100,6 @@ module Aikido::Zen::WorkerProcess
         actor = Aikido::Zen::Actor.from_json(actor_data) if actor_data
         route = Aikido::Zen::Route.from_json(route_data)
         Aikido::Zen.rate_limiter.calculate_rate_limits(RequestKind.new(route, nil, ip, actor))
-      end
-
-      # @return [Boolean]
-      def attack_wave_flagged?(client_ip)
-        @detector.flagged?(client_ip)
       end
 
       # @return [Boolean]

--- a/test/aikido/zen/attack_wave_test.rb
+++ b/test/aikido/zen/attack_wave_test.rb
@@ -97,7 +97,7 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
     # as the local attack_wave_detector. No worker process client is present.
     def attack_wave?(context, detector = build_detector)
       Aikido::Zen.stub(:attack_wave_detector, detector) do
-        Aikido::Zen.attack_wave?(context)
+        Aikido::Zen.detect_attack_wave(context)
       end
     end
 
@@ -282,7 +282,7 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
       assert detector.flagged?("1.2.3.4")
     end
 
-    test "#record shares state with #attack_wave? so a delegated recording is reflected locally" do
+    test "#record shares state with .detect_attack_wave so a delegated recording is reflected locally" do
       detector = build_detector
       sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
 

--- a/test/aikido/zen/attack_wave_test.rb
+++ b/test/aikido/zen/attack_wave_test.rb
@@ -4,6 +4,10 @@ require "test_helper"
 
 class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
   class HelpersTest < ActiveSupport::TestCase
+    def context_for(path, env = {})
+      Aikido::Zen::Context.from_rack_env(Rack::MockRequest.env_for(path, env))
+    end
+
     test "suspicious_path? returns true for foreign extension with 404 status" do
       assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/admin.php", 404)
       assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/app.jsp", 404)
@@ -32,6 +36,26 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
     test "suspicious_path? still returns true for suspicious file names regardless of status" do
       assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/.gitconfig", 200)
       assert Aikido::Zen::AttackWave::Helpers.suspicious_path?("/wp-config.php", 200)
+    end
+
+    test "sample_for builds a sample from the request's verb and path" do
+      context = context_for("/.config?q=1", "REMOTE_ADDR" => "1.2.3.4")
+
+      sample = Aikido::Zen::AttackWave::Helpers.sample_for(context)
+
+      assert_equal "GET", sample.verb
+      assert_equal "/.config?q=1", sample.path
+    end
+
+    test "sample_for uses the original path when Rails has rewritten PATH_INFO for an exceptions_app" do
+      context = context_for("/.config?q=1",
+        "REMOTE_ADDR" => "1.2.3.4",
+        "action_dispatch.original_path" => "/.config",
+        "PATH_INFO" => "/404")
+
+      sample = Aikido::Zen::AttackWave::Helpers.sample_for(context)
+
+      assert_equal "/.config?q=1", sample.path
     end
   end
 
@@ -68,18 +92,27 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
       Aikido::Zen::AttackWave::Detector.new(clock: @clock)
     end
 
+    # Aikido::Zen orchestrates attack wave detection so that it works in the
+    # main process and worker processes. The detector under test is stubbed
+    # as the local attack_wave_detector. No worker process client is present.
+    def attack_wave?(context, detector = build_detector)
+      Aikido::Zen.stub(:attack_wave_detector, detector) do
+        Aikido::Zen.attack_wave?(context)
+      end
+    end
+
     def assert_attack_wave_in(context, detector: nil)
       detector ||= build_detector
-      refute detector.attack_wave?(context)
-      refute detector.attack_wave?(context)
-      assert detector.attack_wave?(context)
+      refute attack_wave?(context, detector)
+      refute attack_wave?(context, detector)
+      assert attack_wave?(context, detector)
     end
 
     def refute_attack_wave_in(context, detector: nil)
       detector ||= build_detector
-      refute detector.attack_wave?(context)
-      refute detector.attack_wave?(context)
-      refute detector.attack_wave?(context)
+      refute attack_wave?(context, detector)
+      refute attack_wave?(context, detector)
+      refute attack_wave?(context, detector)
     end
 
     def assert_attack_wave_for(path, env = {}, detector: nil)
@@ -202,13 +235,13 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
       detector ||= build_detector
 
       context = build_context_for("/.config", DEFAULT_ENV)
-      refute detector.attack_wave?(context)
+      refute attack_wave?(context, detector)
 
       context = build_context_for("/.git/config", DEFAULT_ENV)
-      refute detector.attack_wave?(context)
+      refute attack_wave?(context, detector)
 
       context = build_context_for("/.ssh/known_hosts", DEFAULT_ENV)
-      assert detector.attack_wave?(context)
+      assert attack_wave?(context, detector)
 
       samples = detector.samples[context.request.client_ip]
 
@@ -221,6 +254,43 @@ class Aikido::Zen::AttackWaveTest < ActiveSupport::TestCase
       ]
 
       assert_equal expected, samples.as_json
+    end
+
+    test "#flagged? returns false until the threshold is crossed via #record" do
+      detector = build_detector
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      refute detector.flagged?("1.2.3.4")
+
+      detector.record("1.2.3.4", sample)
+      refute detector.flagged?("1.2.3.4")
+
+      detector.record("1.2.3.4", sample)
+      refute detector.flagged?("1.2.3.4")
+
+      detector.record("1.2.3.4", sample)
+      assert detector.flagged?("1.2.3.4")
+    end
+
+    test "#flag! marks a client IP as flagged directly" do
+      detector = build_detector
+
+      refute detector.flagged?("1.2.3.4")
+
+      detector.flag!("1.2.3.4")
+
+      assert detector.flagged?("1.2.3.4")
+    end
+
+    test "#record shares state with #attack_wave? so a delegated recording is reflected locally" do
+      detector = build_detector
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      refute detector.record("1.2.3.4", sample)
+      refute detector.record("1.2.3.4", sample)
+      assert detector.record("1.2.3.4", sample)
+
+      refute_attack_wave_for("/.config", detector: detector)
     end
   end
 end

--- a/test/aikido/zen/middleware/attack_wave_protector_test.rb
+++ b/test/aikido/zen/middleware/attack_wave_protector_test.rb
@@ -60,7 +60,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     context = build_context_for("/.config", DEFAULT_ENV)
 
     zen.expect :current_context, context
-    zen.expect :attack_wave?, false, [context, 200]
+    zen.expect :detect_attack_wave, nil, [context, 200]
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -68,19 +68,17 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
-    zen.expect :attack_wave?, false, [context, 200]
+    zen.expect :detect_attack_wave, nil, [context, 200]
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
     assert_mock zen
     assert_mock app
-
-    zen.expect :current_context, context
-    zen.expect :attack_wave?, true, [context, 200]
 
     attack_wave = build_attack_wave(context)
 
-    zen.expect :attack_wave_samples, attack_wave.attack.samples, [context.request.client_ip]
+    zen.expect :current_context, context
+    zen.expect :detect_attack_wave, attack_wave.attack.samples, [context, 200]
     zen.expect(:track_attack_wave, nil) do |arg|
       arg.is_a?(Aikido::Zen::Events::AttackWave) &&
         arg.request == attack_wave.request &&

--- a/test/aikido/zen/middleware/attack_wave_protector_test.rb
+++ b/test/aikido/zen/middleware/attack_wave_protector_test.rb
@@ -60,7 +60,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     context = build_context_for("/.config", DEFAULT_ENV)
 
     zen.expect :current_context, context
-    zen.expect :attack_wave_detector, Aikido::Zen.attack_wave_detector
+    zen.expect :attack_wave?, false, [context, 200]
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -68,7 +68,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
-    zen.expect :attack_wave_detector, Aikido::Zen.attack_wave_detector
+    zen.expect :attack_wave?, false, [context, 200]
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -76,10 +76,11 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
-    2.times { zen.expect :attack_wave_detector, Aikido::Zen.attack_wave_detector }
+    zen.expect :attack_wave?, true, [context, 200]
 
     attack_wave = build_attack_wave(context)
 
+    zen.expect :attack_wave_samples, attack_wave.attack.samples, [context.request.client_ip]
     zen.expect(:track_attack_wave, nil) do |arg|
       arg.is_a?(Aikido::Zen::Events::AttackWave) &&
         arg.request == attack_wave.request &&

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -271,6 +271,62 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "#attack_wave_flagged? returns the parent's answer" do
+    build_agent("updated_settings" => {}, "attack_wave_flagged?" => true) do |agent|
+      assert agent.attack_wave_flagged?("1.2.3.4")
+    end
+  end
+
+  test "#attack_wave_flagged? logs and re-raises when the RPC call raises" do
+    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
+      client.stub(:invoke, ->(*) { raise "RPC error" }) do
+        err = assert_raises(RuntimeError) { agent.attack_wave_flagged?("1.2.3.4") }
+        assert_equal "RPC error", err.message
+        assert_logged :error, /failed to check attack wave status with parent/i
+      end
+    end
+  end
+
+  test "#record_attack_wave returns the parent's verdict" do
+    build_agent("updated_settings" => {}, "record_attack_wave" => true) do |agent|
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      assert agent.record_attack_wave("1.2.3.4", sample)
+    end
+  end
+
+  test "#record_attack_wave logs and re-raises when the RPC call raises" do
+    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      client.stub(:invoke, ->(*) { raise "RPC error" }) do
+        err = assert_raises(RuntimeError) { agent.record_attack_wave("1.2.3.4", sample) }
+        assert_equal "RPC error", err.message
+        assert_logged :error, /failed to record attack wave sample with parent/i
+      end
+    end
+  end
+
+  test "#attack_wave_samples parses the samples returned by the parent" do
+    result_data = [{"method" => "GET", "url" => "/.config"}]
+
+    build_agent("updated_settings" => {}, "attack_wave_samples" => result_data) do |agent|
+      samples = agent.attack_wave_samples("1.2.3.4")
+
+      assert_equal [Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")], samples
+    end
+  end
+
+  test "#attack_wave_samples logs and re-raises when the RPC call raises" do
+    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
+      client.stub(:invoke, ->(*) { raise "RPC error" }) do
+        err = assert_raises(RuntimeError) { agent.attack_wave_samples("1.2.3.4") }
+        assert_equal "RPC error", err.message
+        assert_logged :error, /failed to get attack wave samples from parent/i
+      end
+    end
+  end
+
   test "the scheduled keepalive task pings the parent" do
     build_agent("updated_settings" => {}) do |agent, worker, collector, client, keepalive_worker|
       assert_nothing_raised { keepalive_worker.jobs[0].task.call }

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -271,11 +271,23 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "#record_attack_wave returns the parent's verdict" do
-    build_agent("updated_settings" => {}, "record_attack_wave" => true) do |agent|
+  test "#record_attack_wave returns nil when the threshold has not been reached" do
+    build_agent("updated_settings" => {}, "record_attack_wave" => nil) do |agent|
       sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
 
-      assert agent.record_attack_wave("1.2.3.4", sample)
+      assert_nil agent.record_attack_wave("1.2.3.4", sample)
+    end
+  end
+
+  test "#record_attack_wave parses the samples returned by the parent once the threshold is reached" do
+    result_data = [{"method" => "GET", "url" => "/.config"}]
+
+    build_agent("updated_settings" => {}, "record_attack_wave" => result_data) do |agent|
+      sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+      samples = agent.record_attack_wave("1.2.3.4", sample)
+
+      assert_equal [Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")], samples
     end
   end
 
@@ -287,26 +299,6 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
         err = assert_raises(RuntimeError) { agent.record_attack_wave("1.2.3.4", sample) }
         assert_equal "RPC error", err.message
         assert_logged :error, /failed to record attack wave sample with parent/i
-      end
-    end
-  end
-
-  test "#attack_wave_samples parses the samples returned by the parent" do
-    result_data = [{"method" => "GET", "url" => "/.config"}]
-
-    build_agent("updated_settings" => {}, "attack_wave_samples" => result_data) do |agent|
-      samples = agent.attack_wave_samples("1.2.3.4")
-
-      assert_equal [Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")], samples
-    end
-  end
-
-  test "#attack_wave_samples logs and re-raises when the RPC call raises" do
-    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
-      client.stub(:invoke, ->(*) { raise "RPC error" }) do
-        err = assert_raises(RuntimeError) { agent.attack_wave_samples("1.2.3.4") }
-        assert_equal "RPC error", err.message
-        assert_logged :error, /failed to get attack wave samples from parent/i
       end
     end
   end

--- a/test/aikido/zen/worker_process/agent/client_test.rb
+++ b/test/aikido/zen/worker_process/agent/client_test.rb
@@ -271,22 +271,6 @@ class Aikido::Zen::WorkerProcess::Agent::ClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "#attack_wave_flagged? returns the parent's answer" do
-    build_agent("updated_settings" => {}, "attack_wave_flagged?" => true) do |agent|
-      assert agent.attack_wave_flagged?("1.2.3.4")
-    end
-  end
-
-  test "#attack_wave_flagged? logs and re-raises when the RPC call raises" do
-    build_agent("updated_settings" => {}) do |agent, worker, collector, client|
-      client.stub(:invoke, ->(*) { raise "RPC error" }) do
-        err = assert_raises(RuntimeError) { agent.attack_wave_flagged?("1.2.3.4") }
-        assert_equal "RPC error", err.message
-        assert_logged :error, /failed to check attack wave status with parent/i
-      end
-    end
-  end
-
   test "#record_attack_wave returns the parent's verdict" do
     build_agent("updated_settings" => {}, "record_attack_wave" => true) do |agent|
       sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")

--- a/test/aikido/zen/worker_process/agent/server_test.rb
+++ b/test/aikido/zen/worker_process/agent/server_test.rb
@@ -327,28 +327,6 @@ class Aikido::Zen::WorkerProcess::Agent::ServerTest < ActiveSupport::TestCase
     assert_nil received_actor
   end
 
-  test "attack_wave_flagged? handler returns false for a client that has not been recorded" do
-    @server.start
-    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
-
-    refute client.invoke("attack_wave_flagged?", 2.0, "1.2.3.4")
-  ensure
-    client.stop
-  end
-
-  test "attack_wave_flagged? handler returns true once the client has crossed the threshold" do
-    Aikido::Zen.config.attack_wave_threshold = 1
-    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
-    Aikido::Zen.attack_wave_detector.record("1.2.3.4", sample)
-
-    @server.start
-    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
-
-    assert client.invoke("attack_wave_flagged?", 2.0, "1.2.3.4")
-  ensure
-    client.stop
-  end
-
   test "record_attack_wave handler returns false when the threshold has not been reached" do
     Aikido::Zen.config.attack_wave_threshold = 3
 

--- a/test/aikido/zen/worker_process/agent/server_test.rb
+++ b/test/aikido/zen/worker_process/agent/server_test.rb
@@ -326,4 +326,81 @@ class Aikido::Zen::WorkerProcess::Agent::ServerTest < ActiveSupport::TestCase
 
     assert_nil received_actor
   end
+
+  test "attack_wave_flagged? handler returns false for a client that has not been recorded" do
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    refute client.invoke("attack_wave_flagged?", 2.0, "1.2.3.4")
+  ensure
+    client.stop
+  end
+
+  test "attack_wave_flagged? handler returns true once the client has crossed the threshold" do
+    Aikido::Zen.config.attack_wave_threshold = 1
+    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+    Aikido::Zen.attack_wave_detector.record("1.2.3.4", sample)
+
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    assert client.invoke("attack_wave_flagged?", 2.0, "1.2.3.4")
+  ensure
+    client.stop
+  end
+
+  test "record_attack_wave handler returns false when the threshold has not been reached" do
+    Aikido::Zen.config.attack_wave_threshold = 3
+
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    refute client.invoke("record_attack_wave", 2.0, "1.2.3.4", "GET", "/.config")
+  ensure
+    client.stop
+  end
+
+  test "record_attack_wave handler returns true once the threshold is reached" do
+    Aikido::Zen.config.attack_wave_threshold = 1
+
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    assert client.invoke("record_attack_wave", 2.0, "1.2.3.4", "GET", "/.config")
+  ensure
+    client.stop
+  end
+
+  test "#record_attack_wave records the sample against the shared detector" do
+    Aikido::Zen.config.attack_wave_threshold = 1
+
+    assert @server.record_attack_wave("1.2.3.4", "GET", "/.config")
+    assert Aikido::Zen.attack_wave_detector.flagged?("1.2.3.4")
+  end
+
+  test "attack_wave_samples handler returns the samples collected for a client" do
+    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.git/config")
+
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    result = client.invoke("attack_wave_samples", 2.0, "1.2.3.4")
+
+    assert_equal [
+      {"method" => "GET", "url" => "/.config"},
+      {"method" => "GET", "url" => "/.git/config"}
+    ], result
+  ensure
+    client.stop
+  end
+
+  test "attack_wave_samples handler returns an empty array for a client with no samples" do
+    @server.start
+    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
+
+    assert_equal [], client.invoke("attack_wave_samples", 2.0, "1.2.3.4")
+  ensure
+    client.stop
+  end
 end

--- a/test/aikido/zen/worker_process/agent/server_test.rb
+++ b/test/aikido/zen/worker_process/agent/server_test.rb
@@ -356,28 +356,20 @@ class Aikido::Zen::WorkerProcess::Agent::ServerTest < ActiveSupport::TestCase
     assert Aikido::Zen.attack_wave_detector.flagged?("1.2.3.4")
   end
 
-  test "attack_wave_samples handler returns the samples collected for a client" do
-    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
-    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.git/config")
+  test "record_attack_wave handler returns the accumulated samples once the threshold is reached" do
+    Aikido::Zen.config.attack_wave_threshold = 2
 
     @server.start
     client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
 
-    result = client.invoke("attack_wave_samples", 2.0, "1.2.3.4")
+    refute client.invoke("record_attack_wave", 2.0, "1.2.3.4", "GET", "/.config")
+
+    result = client.invoke("record_attack_wave", 2.0, "1.2.3.4", "GET", "/.git/config")
 
     assert_equal [
       {"method" => "GET", "url" => "/.config"},
       {"method" => "GET", "url" => "/.git/config"}
     ], result
-  ensure
-    client.stop
-  end
-
-  test "attack_wave_samples handler returns an empty array for a client with no samples" do
-    @server.start
-    client = Aikido::Zen::RPC::Client.start(Aikido::Zen.secret, @server.host, @server.port)
-
-    assert_equal [], client.invoke("attack_wave_samples", 2.0, "1.2.3.4")
   ensure
     client.stop
   end

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class Aikido::ZenTest < ActiveSupport::TestCase
+  def context_for(path, env = {})
+    Aikido::Zen::Context.from_rack_env(Rack::MockRequest.env_for(path, env))
+  end
+
   test "it has a version number" do
     refute_nil ::Aikido::Zen::VERSION
   end
@@ -175,5 +179,145 @@ class Aikido::ZenTest < ActiveSupport::TestCase
 
     assert_equal :local_result, result
     assert_mock rate_limiter_mock
+  end
+
+  test ".attack_wave? delegates to the local detector when there is no detached agent" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    mock = Minitest::Mock.new
+    mock.expect(:flagged?, false, ["1.2.3.4"])
+    mock.expect(:record, true, ["1.2.3.4", Object])
+
+    result = Aikido::Zen.stub(:attack_wave_detector, mock) do
+      Aikido::Zen.attack_wave?(context)
+    end
+
+    assert result
+    assert_mock mock
+  end
+
+  test ".attack_wave? returns false without submitting when the client is already flagged" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    mock = Minitest::Mock.new
+    mock.expect(:attack_wave_flagged?, true, ["1.2.3.4"])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
+
+    refute Aikido::Zen.attack_wave?(context)
+    assert_mock mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave? never calls the detached agent's record when the request isn't suspicious" do
+    context = context_for("/safe", "REMOTE_ADDR" => "1.2.3.4")
+
+    mock = Minitest::Mock.new
+    mock.expect(:attack_wave_flagged?, false, ["1.2.3.4"])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
+
+    refute Aikido::Zen.attack_wave?(context)
+    assert_mock mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave? classifies locally and submits the sample when the client isn't flagged" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    mock = Minitest::Mock.new
+    mock.expect(:attack_wave_flagged?, false, ["1.2.3.4"])
+    mock.expect(:record_attack_wave, true, ["1.2.3.4", Object])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
+
+    assert Aikido::Zen.attack_wave?(context)
+    assert_mock mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave? falls back to the local detector's flagged check when that RPC call raises" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    failing_client = Minitest::Mock.new
+    failing_client.expect(:attack_wave_flagged?, nil) { |*| raise "RPC error" }
+    failing_client.expect(:record_attack_wave, true, ["1.2.3.4", Object])
+
+    detector_mock = Minitest::Mock.new
+    detector_mock.expect(:flagged?, false, ["1.2.3.4"])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
+
+    result = Aikido::Zen.stub(:attack_wave_detector, detector_mock) do
+      Aikido::Zen.attack_wave?(context)
+    end
+
+    assert result
+    assert_mock failing_client
+    assert_mock detector_mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave? falls back to the local detector's record when that RPC call raises" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+
+    failing_client = Minitest::Mock.new
+    failing_client.expect(:attack_wave_flagged?, false, ["1.2.3.4"])
+    failing_client.expect(:record_attack_wave, nil) { |*| raise "RPC error" }
+
+    detector_mock = Minitest::Mock.new
+    detector_mock.expect(:record, true, ["1.2.3.4", Object])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
+
+    result = Aikido::Zen.stub(:attack_wave_detector, detector_mock) do
+      Aikido::Zen.attack_wave?(context)
+    end
+
+    assert result
+    assert_mock failing_client
+    assert_mock detector_mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave_samples returns the local detector's collected samples when there is no detached agent" do
+    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= sample
+
+    assert_equal [sample], Aikido::Zen.attack_wave_samples("1.2.3.4")
+  end
+
+  test ".attack_wave_samples delegates to the detached agent when one is set" do
+    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+
+    mock = Minitest::Mock.new
+    mock.expect(:attack_wave_samples, [sample], ["1.2.3.4"])
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
+
+    assert_equal [sample], Aikido::Zen.attack_wave_samples("1.2.3.4")
+    assert_mock mock
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
+  end
+
+  test ".attack_wave_samples falls back to the local detector when the detached agent raises" do
+    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= sample
+
+    failing_client = Minitest::Mock.new
+    failing_client.expect(:attack_wave_samples, nil) { |*| raise "RPC error" }
+
+    Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
+
+    assert_equal [sample], Aikido::Zen.attack_wave_samples("1.2.3.4")
+    assert_mock failing_client
+  ensure
+    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 end

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -185,7 +185,6 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
-    mock.expect(:flagged?, false, ["1.2.3.4"])
     mock.expect(:record, true, ["1.2.3.4", Object])
 
     result = Aikido::Zen.stub(:attack_wave_detector, mock) do
@@ -196,11 +195,11 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     assert_mock mock
   end
 
-  test ".attack_wave? returns false without submitting when the client is already flagged" do
+  test ".attack_wave? returns whatever record_attack_wave reports, even when the client is already flagged" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
-    mock.expect(:attack_wave_flagged?, true, ["1.2.3.4"])
+    mock.expect(:record_attack_wave, false, ["1.2.3.4", Object])
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
@@ -210,11 +209,10 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave? never calls the detached agent's record when the request isn't suspicious" do
+  test ".attack_wave? never calls the detached agent when the request isn't suspicious" do
     context = context_for("/safe", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
-    mock.expect(:attack_wave_flagged?, false, ["1.2.3.4"])
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
@@ -224,11 +222,10 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave? classifies locally and submits the sample when the client isn't flagged" do
+  test ".attack_wave? classifies locally and submits the sample when the request is suspicious" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
-    mock.expect(:attack_wave_flagged?, false, ["1.2.3.4"])
     mock.expect(:record_attack_wave, true, ["1.2.3.4", Object])
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
@@ -239,34 +236,10 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave? falls back to the local detector's flagged check when that RPC call raises" do
+  test ".attack_wave? falls back to the local detector when the RPC call raises" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     failing_client = Minitest::Mock.new
-    failing_client.expect(:attack_wave_flagged?, nil) { |*| raise "RPC error" }
-    failing_client.expect(:record_attack_wave, true, ["1.2.3.4", Object])
-
-    detector_mock = Minitest::Mock.new
-    detector_mock.expect(:flagged?, false, ["1.2.3.4"])
-
-    Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
-
-    result = Aikido::Zen.stub(:attack_wave_detector, detector_mock) do
-      Aikido::Zen.attack_wave?(context)
-    end
-
-    assert result
-    assert_mock failing_client
-    assert_mock detector_mock
-  ensure
-    Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
-  end
-
-  test ".attack_wave? falls back to the local detector's record when that RPC call raises" do
-    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
-
-    failing_client = Minitest::Mock.new
-    failing_client.expect(:attack_wave_flagged?, false, ["1.2.3.4"])
     failing_client.expect(:record_attack_wave, nil) { |*| raise "RPC error" }
 
     detector_mock = Minitest::Mock.new

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -181,21 +181,21 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     assert_mock rate_limiter_mock
   end
 
-  test ".attack_wave? delegates to the local detector when there is no detached agent" do
+  test ".detect_attack_wave delegates to the local detector when there is no detached agent" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
     mock.expect(:record, true, ["1.2.3.4", Object])
 
     result = Aikido::Zen.stub(:attack_wave_detector, mock) do
-      Aikido::Zen.attack_wave?(context)
+      Aikido::Zen.detect_attack_wave(context)
     end
 
     assert result
     assert_mock mock
   end
 
-  test ".attack_wave? returns whatever record_attack_wave reports, even when the client is already flagged" do
+  test ".detect_attack_wave reflects record_attack_wave's outcome, even when the client is already flagged" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
@@ -203,26 +203,26 @@ class Aikido::ZenTest < ActiveSupport::TestCase
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
-    refute Aikido::Zen.attack_wave?(context)
+    refute Aikido::Zen.detect_attack_wave(context)
     assert_mock mock
   ensure
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave? never calls the detached agent when the request isn't suspicious" do
+  test ".detect_attack_wave never calls the detached agent when the request isn't suspicious" do
     context = context_for("/safe", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
-    refute Aikido::Zen.attack_wave?(context)
+    refute Aikido::Zen.detect_attack_wave(context)
     assert_mock mock
   ensure
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave? classifies locally and submits the sample when the request is suspicious" do
+  test ".detect_attack_wave classifies locally and submits the sample when the request is suspicious" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     mock = Minitest::Mock.new
@@ -230,13 +230,13 @@ class Aikido::ZenTest < ActiveSupport::TestCase
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
-    assert Aikido::Zen.attack_wave?(context)
+    assert Aikido::Zen.detect_attack_wave(context)
     assert_mock mock
   ensure
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave? falls back to the local detector when the RPC call raises" do
+  test ".detect_attack_wave falls back to the local detector when the RPC call raises" do
     context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
     failing_client = Minitest::Mock.new
@@ -248,7 +248,7 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
 
     result = Aikido::Zen.stub(:attack_wave_detector, detector_mock) do
-      Aikido::Zen.attack_wave?(context)
+      Aikido::Zen.detect_attack_wave(context)
     end
 
     assert result
@@ -258,38 +258,31 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave_samples returns the local detector's collected samples when there is no detached agent" do
-    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
-    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= sample
-
-    assert_equal [sample], Aikido::Zen.attack_wave_samples("1.2.3.4")
-  end
-
-  test ".attack_wave_samples delegates to the detached agent when one is set" do
-    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
+  test ".detect_attack_wave returns the samples that crossed the threshold, not just a flag" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
+    samples = [Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")]
 
     mock = Minitest::Mock.new
-    mock.expect(:attack_wave_samples, [sample], ["1.2.3.4"])
+    mock.expect(:record_attack_wave, samples, ["1.2.3.4", Object])
 
     Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
-    assert_equal [sample], Aikido::Zen.attack_wave_samples("1.2.3.4")
+    assert_equal samples, Aikido::Zen.detect_attack_wave(context)
     assert_mock mock
   ensure
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end
 
-  test ".attack_wave_samples falls back to the local detector when the detached agent raises" do
-    sample = Aikido::Zen::AttackWave::Sample.new(verb: "GET", path: "/.config")
-    Aikido::Zen.attack_wave_detector.samples["1.2.3.4"] <<= sample
+  test ".detect_attack_wave returns nil when the threshold was not crossed" do
+    context = context_for("/.config", "REMOTE_ADDR" => "1.2.3.4")
 
-    failing_client = Minitest::Mock.new
-    failing_client.expect(:attack_wave_samples, nil) { |*| raise "RPC error" }
+    mock = Minitest::Mock.new
+    mock.expect(:record_attack_wave, nil, ["1.2.3.4", Object])
 
-    Aikido::Zen.instance_variable_set(:@worker_process_client, failing_client)
+    Aikido::Zen.instance_variable_set(:@worker_process_client, mock)
 
-    assert_equal [sample], Aikido::Zen.attack_wave_samples("1.2.3.4")
-    assert_mock failing_client
+    assert_nil Aikido::Zen.detect_attack_wave(context)
+    assert_mock mock
   ensure
     Aikido::Zen.instance_variable_set(:@worker_process_client, nil)
   end


### PR DESCRIPTION
This change centralizes attack wave detection state in the main process, and provides access to this centralized state in worker processes through the `record_attack_wave` and `attack_wave_samples` RPC calls. Should an RPC call fail then the worker process falls back to the local attack wave detection state until the next RPC call. For sustained PRC failure this gracefully moves attack wave detection state to the worker process.

This helps ensure that an attack waves is detected after the configured attack wave threshold and are tracked once, in the process that detected it.

The attack wave detection state is now separate from the attack wave detection logic itself. Attack wave detection is still performed in the worker process. Attack wave detection state is centralized in the main process under normal operation. `Aikido::Zen` orchestrates attack wave detection so that it works correctly in the main process and worker processes.

The pre-existing optimization of whether the client IP has been flagged as the origin of an attack wave has been retired due to the complexity and cost of synchronizing the flagged cache state. `Aikido::Zen::AttackWave::Detector#record` now does this check only to guarantee the minimum time between recording attack wave events.

This change supersedes #369.