### PR TITLE
Support request bypassing middleware

### DIFF
--- a/docs/request-bypassing.md
+++ b/docs/request-bypassing.md
@@ -1,0 +1,38 @@
+# Bypass Zen for a specific request
+
+To disable Zen for a specific request, call `Aikido::Zen.request_bypassed!` from a Rack middleware. This bypasses Zen's security checks and stats collection for that request.
+
+> [!NOTE]
+> Zen already has a built-in feature for bypassing specific IP addresses. This feature offers more flexibility, letting you bypass Zen for a request based on any criteria you choose.
+
+`Aikido::Zen.request_bypassed!` needs the request's context to already be set up, so your middleware must run after Zen's `ContextSetter` middleware. The following example shows how to bypass a specific request in a Rails application:
+
+```ruby
+# config/application.rb
+class RequestBypasser
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if your_custom_logic?(env)
+      Aikido::Zen.request_bypassed! # Bypasses Zen for this request
+    end
+
+    @app.call(env)
+  end
+end
+
+module YourApp
+  class Application < Rails::Application
+    # ...
+
+    initializer "your_app.insert_request_bypasser", after: "aikido.add_middleware" do |app|
+      app.middleware.insert_after Aikido::Zen::Middleware::ContextSetter, RequestBypasser
+    end
+  end
+end
+```
+
+> [!WARNING]
+> Use this feature with caution, as it can potentially expose your application to security risks if not used properly.

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -158,7 +158,9 @@ module Aikido
       context = current_context
       return unless context
 
-      context.request_bypassed ||= runtime_settings.bypassed_ip?(context.request.client_ip)
+      return context.request_bypassed unless context.request_bypassed.nil?
+
+      context.request_bypassed = runtime_settings.bypassed_ip?(context.request.client_ip)
     end
 
     # Marks the current request as bypassed.

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -158,7 +158,14 @@ module Aikido
       context = current_context
       return unless context
 
-      runtime_settings.bypassed_ip?(context.request.client_ip)
+      context.request_bypassed ||= runtime_settings.bypassed_ip?(context.request.client_ip)
+    end
+
+    # Marks the current request as bypassed.
+    #
+    # @return [void]
+    def self.request_bypassed!
+      current_context&.request_bypassed = true
     end
 
     # Track statistics about an HTTP request the app is handling.

--- a/lib/aikido/zen.rb
+++ b/lib/aikido/zen.rb
@@ -153,6 +153,14 @@ module Aikido
       Fiber.current.aikido_current_context = context
     end
 
+    # @return [Boolean] whether the current request is bypassed.
+    def self.request_bypassed?
+      context = current_context
+      return unless context
+
+      runtime_settings.bypassed_ip?(context.request.client_ip)
+    end
+
     # Track statistics about an HTTP request the app is handling.
     #
     # @param request [Aikido::Zen::Request]

--- a/lib/aikido/zen/context.rb
+++ b/lib/aikido/zen/context.rb
@@ -24,6 +24,10 @@ module Aikido::Zen
     attr_accessor :scanning
     alias_method :scanning?, :scanning
 
+    # @return [Boolean] whether the request is bypassed.
+    attr_accessor :request_bypassed
+    alias_method :request_bypassed?, :request_bypassed
+
     # @return [Boolean] whether attack protection for the currently requested
     #   endpoint was disabled on the Aikido dashboard, or if the source IP for
     #   this request is in the "Bypass List".
@@ -48,6 +52,7 @@ module Aikido::Zen
 
       @metadata = {}
       @scanning = false
+      @request_bypassed = false
       @protection_disabled = false
       @idor_protection_enabled = false
     end

--- a/lib/aikido/zen/context.rb
+++ b/lib/aikido/zen/context.rb
@@ -24,7 +24,7 @@ module Aikido::Zen
     attr_accessor :scanning
     alias_method :scanning?, :scanning
 
-    # @return [Boolean] whether the request is bypassed.
+    # @return [Boolean, nil] whether the request is bypassed.
     attr_accessor :request_bypassed
     alias_method :request_bypassed?, :request_bypassed
 
@@ -52,7 +52,7 @@ module Aikido::Zen
 
       @metadata = {}
       @scanning = false
-      @request_bypassed = false
+      @request_bypassed = nil
       @protection_disabled = false
       @idor_protection_enabled = false
     end

--- a/lib/aikido/zen/middleware/allowed_address_checker.rb
+++ b/lib/aikido/zen/middleware/allowed_address_checker.rb
@@ -5,8 +5,9 @@ module Aikido::Zen
     # Middleware that only allows allowed IPs when allowed IPs are configured for
     # any matching route in the Aikido dashboard.
     class AllowedAddressChecker
-      def initialize(app, config: Aikido::Zen.config, settings: Aikido::Zen.runtime_settings)
+      def initialize(app, zen: Aikido::Zen, config: zen.config, settings: zen.runtime_settings)
         @app = app
+        @zen = zen
         @config = config
         @settings = settings
       end
@@ -22,7 +23,7 @@ module Aikido::Zen
       end
 
       private def allowed?(request)
-        return true if @settings.bypassed_ips.include?(request.client_ip)
+        return true if @zen.request_bypassed?
 
         matches = @settings.endpoints.matched_settings(request.route)
 

--- a/lib/aikido/zen/middleware/attack_protector.rb
+++ b/lib/aikido/zen/middleware/attack_protector.rb
@@ -19,7 +19,7 @@ module Aikido::Zen
       end
 
       private def protection_disabled?(request)
-        return true if @settings.bypassed_ips.include?(request.client_ip)
+        return true if @zen.request_bypassed?
 
         !@settings.endpoints.matched_settings(request.route).all?(&:protected?)
       end

--- a/lib/aikido/zen/middleware/attack_wave_protector.rb
+++ b/lib/aikido/zen/middleware/attack_wave_protector.rb
@@ -4,10 +4,9 @@ module Aikido
   module Zen
     module Middleware
       class AttackWaveProtector
-        def initialize(app, zen: Aikido::Zen, settings: Aikido::Zen.runtime_settings)
+        def initialize(app, zen: Aikido::Zen)
           @app = app
           @zen = zen
-          @settings = settings
         end
 
         def call(env)
@@ -30,7 +29,7 @@ module Aikido
           request = context.request
           return nil if request.nil?
 
-          return nil if @settings.bypassed_ips.include?(request.client_ip)
+          return nil if @zen.request_bypassed?
 
           @zen.detect_attack_wave(context, status_code)
         end

--- a/lib/aikido/zen/middleware/ip_list_checker.rb
+++ b/lib/aikido/zen/middleware/ip_list_checker.rb
@@ -15,7 +15,7 @@ module Aikido::Zen
 
         client_ip = request.client_ip
 
-        return @app.call(env) if bypassed_ip?(client_ip)
+        return @app.call(env) if @zen.request_bypassed?
 
         if !@settings.allowed_ip?(client_ip)
           return @config.blocked_responder.call(request, :ip_allowed_list)
@@ -37,10 +37,6 @@ module Aikido::Zen
         end
 
         @app.call(env)
-      end
-
-      def bypassed_ip?(client_ip)
-        @settings.bypassed_ips.include?(client_ip)
       end
     end
   end

--- a/lib/aikido/zen/middleware/rack_throttler.rb
+++ b/lib/aikido/zen/middleware/rack_throttler.rb
@@ -34,7 +34,7 @@ module Aikido::Zen
       private
 
       def should_throttle?(request)
-        return false if @settings.bypassed_ips.include?(request.client_ip)
+        return false if @zen.request_bypassed?
 
         return false if request.actor && @settings.user_excluded_from_rate_limiting?(request.actor.id)
 

--- a/lib/aikido/zen/middleware/request_tracker.rb
+++ b/lib/aikido/zen/middleware/request_tracker.rb
@@ -5,8 +5,9 @@ module Aikido::Zen
     # Rack middleware used to track request
     # It implements the logic under that which is considered worthy of being tracked.
     class RequestTracker
-      def initialize(app, settings: Aikido::Zen.runtime_settings)
+      def initialize(app, zen: Aikido::Zen, settings: zen.runtime_settings)
         @app = app
+        @zen = zen
         @settings = settings
       end
 
@@ -17,13 +18,12 @@ module Aikido::Zen
         if request.route && track?(
           status_code: response[0],
           route: request.route.path,
-          http_method: request.request_method,
-          ip: request.client_ip
+          http_method: request.request_method
         )
-          Aikido::Zen.track_request(request)
+          @zen.track_request(request)
 
-          if Aikido::Zen.config.collect_api_schema?
-            Aikido::Zen.track_discovered_route(request)
+          if @zen.config.collect_api_schema?
+            @zen.track_discovered_route(request)
           end
         end
 
@@ -128,8 +128,8 @@ module Aikido::Zen
       # @param status_code [Integer]
       # @param route [String]
       # @param http_method [String]
-      def track?(status_code:, route:, http_method:, ip: nil)
-        return false if @settings.bypassed_ips.include?(ip)
+      def track?(status_code:, route:, http_method:)
+        return false if @zen.request_bypassed?
 
         # In the UI we want to show only successful (2xx) or redirect (3xx) responses
         # anything else is discarded.

--- a/lib/aikido/zen/middleware/user_agent_checker.rb
+++ b/lib/aikido/zen/middleware/user_agent_checker.rb
@@ -13,7 +13,7 @@ module Aikido::Zen
       def call(env)
         request = Aikido::Zen::Middleware.request_from(env)
 
-        return @app.call(env) if bypassed?(request)
+        return @app.call(env) if @zen.request_bypassed?
 
         user_agent = request.user_agent
 
@@ -30,10 +30,6 @@ module Aikido::Zen
         end
 
         @app.call(env)
-      end
-
-      def bypassed?(request)
-        @settings.bypassed_ips.include?(request.client_ip)
       end
     end
   end

--- a/lib/aikido/zen/sinks/action_controller.rb
+++ b/lib/aikido/zen/sinks/action_controller.rb
@@ -30,7 +30,7 @@ module Aikido::Zen
 
           request = context.request
 
-          return false if @settings.bypassed_ips.include?(request.client_ip)
+          return false if @zen.request_bypassed?
 
           if should_block_user?(request)
             status, headers, body = @config.blocked_responder.call(request, :user)

--- a/lib/aikido/zen/sinks/async_http.rb
+++ b/lib/aikido/zen/sinks/async_http.rb
@@ -52,9 +52,7 @@ module Aikido::Zen
 
                 settings = Aikido::Zen.runtime_settings
 
-                client_ip = context&.request&.client_ip
-
-                unless settings.bypassed_ip?(client_ip)
+                unless Aikido::Zen.request_bypassed?
                   Aikido::Zen.track_outbound(connection)
 
                   if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/curb.rb
+++ b/lib/aikido/zen/sinks/curb.rb
@@ -64,9 +64,7 @@ module Aikido::Zen
 
               settings = Aikido::Zen.runtime_settings
 
-              client_ip = context&.request&.client_ip
-
-              unless settings.bypassed_ip?(client_ip)
+              unless Aikido::Zen.request_bypassed?
                 Aikido::Zen.track_outbound(connection)
 
                 if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/em_http.rb
+++ b/lib/aikido/zen/sinks/em_http.rb
@@ -50,9 +50,7 @@ module Aikido::Zen
 
                 settings = Aikido::Zen.runtime_settings
 
-                client_ip = context&.request&.client_ip
-
-                unless settings.bypassed_ip?(client_ip)
+                unless Aikido::Zen.request_bypassed?
                   Aikido::Zen.track_outbound(connection)
 
                   if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/excon.rb
+++ b/lib/aikido/zen/sinks/excon.rb
@@ -56,9 +56,7 @@ module Aikido::Zen
 
               settings = Aikido::Zen.runtime_settings
 
-              client_ip = context&.request&.client_ip
-
-              unless settings.bypassed_ip?(client_ip)
+              unless Aikido::Zen.request_bypassed?
                 Aikido::Zen.track_outbound(connection)
 
                 if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/http.rb
+++ b/lib/aikido/zen/sinks/http.rb
@@ -70,9 +70,7 @@ module Aikido::Zen
 
               settings = Aikido::Zen.runtime_settings
 
-              client_ip = context&.request&.client_ip
-
-              unless settings.bypassed_ip?(client_ip)
+              unless Aikido::Zen.request_bypassed?
                 Aikido::Zen.track_outbound(connection)
 
                 if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/httpclient.rb
+++ b/lib/aikido/zen/sinks/httpclient.rb
@@ -50,9 +50,7 @@ module Aikido::Zen
 
           settings = Aikido::Zen.runtime_settings
 
-          client_ip = context&.request&.client_ip
-
-          unless settings.bypassed_ip?(client_ip)
+          unless Aikido::Zen.request_bypassed?
             Aikido::Zen.track_outbound(connection)
 
             if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/httpx.rb
+++ b/lib/aikido/zen/sinks/httpx.rb
@@ -55,9 +55,7 @@ module Aikido::Zen
 
               settings = Aikido::Zen.runtime_settings
 
-              client_ip = context&.request&.client_ip
-
-              unless settings.bypassed_ip?(client_ip)
+              unless Aikido::Zen.request_bypassed?
                 Aikido::Zen.track_outbound(connection)
 
                 if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/net_http.rb
+++ b/lib/aikido/zen/sinks/net_http.rb
@@ -86,9 +86,7 @@ module Aikido::Zen
 
               settings = Aikido::Zen.runtime_settings
 
-              client_ip = context&.request&.client_ip
-
-              unless settings.bypassed_ip?(client_ip)
+              unless Aikido::Zen.request_bypassed?
                 Aikido::Zen.track_outbound(connection)
 
                 if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/patron.rb
+++ b/lib/aikido/zen/sinks/patron.rb
@@ -59,9 +59,7 @@ module Aikido::Zen
 
               settings = Aikido::Zen.runtime_settings
 
-              client_ip = context&.request&.client_ip
-
-              unless settings.bypassed_ip?(client_ip)
+              unless Aikido::Zen.request_bypassed?
                 Aikido::Zen.track_outbound(connection)
 
                 if settings.block_outbound?(connection)

--- a/lib/aikido/zen/sinks/typhoeus.rb
+++ b/lib/aikido/zen/sinks/typhoeus.rb
@@ -26,9 +26,7 @@ module Aikido::Zen
 
         settings = Aikido::Zen.runtime_settings
 
-        client_ip = context&.request&.client_ip
-
-        unless settings.bypassed_ip?(client_ip)
+        unless Aikido::Zen.request_bypassed?
           Aikido::Zen.track_outbound(connection)
 
           if settings.block_outbound?(connection)

--- a/test/aikido/zen/context_test.rb
+++ b/test/aikido/zen/context_test.rb
@@ -115,6 +115,11 @@ class Aikido::Zen::ContextTest < ActiveSupport::TestCase
       refute context.scanning?
     end
 
+    test "#request_bypassed? is false by default" do
+      context = build_context_for("/path")
+      refute context.request_bypassed?
+    end
+
     test "#protection_disabled? is false by default" do
       context = build_context_for("/path")
       refute context.protection_disabled?

--- a/test/aikido/zen/context_test.rb
+++ b/test/aikido/zen/context_test.rb
@@ -115,9 +115,9 @@ class Aikido::Zen::ContextTest < ActiveSupport::TestCase
       refute context.scanning?
     end
 
-    test "#request_bypassed? is false by default" do
+    test "#request_bypassed? is nil by default" do
       context = build_context_for("/path")
-      refute context.request_bypassed?
+      assert_nil context.request_bypassed?
     end
 
     test "#protection_disabled? is false by default" do

--- a/test/aikido/zen/middleware/allowed_address_checker_test.rb
+++ b/test/aikido/zen/middleware/allowed_address_checker_test.rb
@@ -38,7 +38,8 @@ class Aikido::Zen::Middleware::AllowedAddressCheckerTest < ActiveSupport::TestCa
     add_allowed_ips "GET", "/admin/portal", ips: ["1.2.3.4", "2.3.4.5"]
 
     env = Rack::MockRequest.env_for("/admin/portal", "REMOTE_ADDR" => "3.4.5.6")
-    response = @middleware.call(env)
+    middleware = Aikido::Zen::Middleware::ContextSetter.new(@middleware)
+    response = middleware.call(env)
 
     assert_equal [200, {}, ["OK"]], response
     assert_passed_to_downstream
@@ -173,6 +174,7 @@ class Aikido::Zen::Middleware::AllowedAddressCheckerTest < ActiveSupport::TestCa
 
     context = Aikido::Zen::Context.from_rack_env(env)
     verifier = Minitest::Mock.new(context)
+    verifier.expect :request, context.request
     verifier.expect :request, context.request
     Aikido::Zen.current_context = verifier
 

--- a/test/aikido/zen/middleware/attack_protector_test.rb
+++ b/test/aikido/zen/middleware/attack_protector_test.rb
@@ -21,6 +21,7 @@ class Aikido::Zen::Middleware::AttackProtectorTest < ActiveSupport::TestCase
       assert_mock app
 
       zen.expect :current_context, context
+      zen.expect :request_bypassed?, @settings.bypassed_ip?(context.request.client_ip)
       app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
       middleware.call({})
       assert_mock zen

--- a/test/aikido/zen/middleware/attack_wave_protector_test.rb
+++ b/test/aikido/zen/middleware/attack_wave_protector_test.rb
@@ -60,6 +60,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     context = build_context_for("/.config", DEFAULT_ENV)
 
     zen.expect :current_context, context
+    zen.expect :request_bypassed?, false
     zen.expect :detect_attack_wave, nil, [context, 200]
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
@@ -68,6 +69,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
+    zen.expect :request_bypassed?, false
     zen.expect :detect_attack_wave, nil, [context, 200]
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
@@ -78,6 +80,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     attack_wave = build_attack_wave(context)
 
     zen.expect :current_context, context
+    zen.expect :request_bypassed?, false
     zen.expect :detect_attack_wave, attack_wave.attack.samples, [context, 200]
     zen.expect(:track_attack_wave, nil) do |arg|
       arg.is_a?(Aikido::Zen::Events::AttackWave) &&
@@ -109,6 +112,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     context = build_context_for("/.config", DEFAULT_ENV)
 
     zen.expect :current_context, context
+    zen.expect :request_bypassed?, true
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -116,6 +120,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
+    zen.expect :request_bypassed?, true
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 
@@ -123,6 +128,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
 
     zen.expect :current_context, context
+    zen.expect :request_bypassed?, true
     app.expect(:call, [200, {}, ["OK"]]) { |arg| arg.is_a?(Hash) }
     middleware.call({})
 

--- a/test/aikido/zen/middleware/attack_wave_protector_test.rb
+++ b/test/aikido/zen/middleware/attack_wave_protector_test.rb
@@ -46,8 +46,6 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
 
   setup do
     Aikido::Zen.config.attack_wave_threshold = 3
-
-    @settings = Aikido::Zen.runtime_settings
   end
 
   test "#call detects attack waves and collects statistics then reports the event" do
@@ -101,9 +99,7 @@ class Aikido::Zen::Middleware::AttackWaveProtectorTest < ActiveSupport::TestCase
     assert_mock app
   end
 
-  test "#call detects attack waves, collects statistics, and reports the event, unless the request IP is an bypassed IP" do
-    @settings.bypassed_ips = Aikido::Zen::RuntimeSettings::IPSet.from_json(["1.2.3.4"])
-
+  test "#call detects attack waves, collects statistics, and reports the event, unless the request is bypassed" do
     app = Minitest::Mock.new
     zen = Minitest::Mock.new
 

--- a/test/aikido/zen/middleware/ip_list_checker_test.rb
+++ b/test/aikido/zen/middleware/ip_list_checker_test.rb
@@ -261,7 +261,8 @@ class Aikido::Zen::Middleware::IPListCheckerTest < ActiveSupport::TestCase
 
       env = env_for("/", {"HTTP_X_FORWARDED_FOR" => "2.16.53.5"})
 
-      status, = @middleware.call(env)
+      middleware = Aikido::Zen::Middleware::ContextSetter.new(@middleware)
+      status, = middleware.call(env)
 
       assert_equal 200, status
 

--- a/test/aikido/zen/middleware/rack_throttler_test.rb
+++ b/test/aikido/zen/middleware/rack_throttler_test.rb
@@ -108,10 +108,11 @@ class Aikido::Zen::Middleware::RackThrottlerTest < ActiveSupport::TestCase
     @app.expect :call, [200, {}, ["OK"]], [Hash]
 
     env = Rack::MockRequest.env_for("/", "REMOTE_ADDR" => "1.2.3.4")
-    assert_equal [200, {}, ["OK"]], @middleware.call(env)
-    assert_equal [200, {}, ["OK"]], @middleware.call(env)
-    assert_equal [200, {}, ["OK"]], @middleware.call(env)
-    assert_equal [200, {}, ["OK"]], @middleware.call(env)
+    middleware = Aikido::Zen::Middleware::ContextSetter.new(@middleware)
+    assert_equal [200, {}, ["OK"]], middleware.call(env)
+    assert_equal [200, {}, ["OK"]], middleware.call(env)
+    assert_equal [200, {}, ["OK"]], middleware.call(env)
+    assert_equal [200, {}, ["OK"]], middleware.call(env)
 
     refute env.key?("aikido.rate_limiting")
     assert_mock @app
@@ -191,6 +192,7 @@ class Aikido::Zen::Middleware::RackThrottlerTest < ActiveSupport::TestCase
 
     context = Aikido::Zen::Context.from_rack_env(env)
     verifier = Minitest::Mock.new(context)
+    verifier.expect :request, context.request
     verifier.expect :request, context.request
     Aikido::Zen.current_context = verifier
 

--- a/test/aikido/zen/middleware/request_tracker_test.rb
+++ b/test/aikido/zen/middleware/request_tracker_test.rb
@@ -48,11 +48,12 @@ class Aikido::Zen::Middleware::RequestTrackerTest < ActiveSupport::TestCase
   test "requests & routes are tracked in our stats funnel, unless the request IP is an bypassed IP" do
     @settings.bypassed_ips = Aikido::Zen::RuntimeSettings::IPSet.from_json(["1.2.3.4"])
 
-    @middleware.call(Rack::MockRequest.env_for("/200", "REMOTE_ADDR" => "1.2.3.4"))
-    @middleware.call(Rack::MockRequest.env_for("/200", "REMOTE_ADDR" => "1.2.3.4"))
-    @middleware.call(Rack::MockRequest.env_for("/100", "REMOTE_ADDR" => "1.2.3.4"))
-    @middleware.call(Rack::MockRequest.env_for("/200", "REMOTE_ADDR" => "1.2.3.4"))
-    @middleware.call(Rack::MockRequest.env_for("/400", "REMOTE_ADDR" => "1.2.3.4"))
+    middleware = Aikido::Zen::Middleware::ContextSetter.new(@middleware)
+    middleware.call(Rack::MockRequest.env_for("/200", "REMOTE_ADDR" => "1.2.3.4"))
+    middleware.call(Rack::MockRequest.env_for("/200", "REMOTE_ADDR" => "1.2.3.4"))
+    middleware.call(Rack::MockRequest.env_for("/100", "REMOTE_ADDR" => "1.2.3.4"))
+    middleware.call(Rack::MockRequest.env_for("/200", "REMOTE_ADDR" => "1.2.3.4"))
+    middleware.call(Rack::MockRequest.env_for("/400", "REMOTE_ADDR" => "1.2.3.4"))
 
     assert_equal 0, Aikido::Zen.collector.stats.requests
     assert_equal 0, Aikido::Zen.collector.routes.visits.size

--- a/test/aikido/zen_test.rb
+++ b/test/aikido/zen_test.rb
@@ -21,6 +21,56 @@ class Aikido::ZenTest < ActiveSupport::TestCase
     assert_equal true, Aikido::Zen.blocking_mode?
   end
 
+  test ".request_bypassed? returns nil if there is no current context" do
+    assert_nil Aikido::Zen.current_context
+
+    assert_nil Aikido::Zen.request_bypassed?
+  end
+
+  test ".request_bypassed? returns true if the request IP is in the bypassed IP set" do
+    Aikido::Zen.runtime_settings.bypassed_ips = Aikido::Zen::RuntimeSettings::IPSet.from_json(["1.2.3.4"])
+    Aikido::Zen.current_context = context_for("/", "REMOTE_ADDR" => "1.2.3.4")
+
+    assert Aikido::Zen.request_bypassed?
+  end
+
+  test ".request_bypassed? returns false if the request IP is not in the bypassed IP set" do
+    Aikido::Zen.runtime_settings.bypassed_ips = Aikido::Zen::RuntimeSettings::IPSet.from_json(["1.2.3.4"])
+    Aikido::Zen.current_context = context_for("/", "REMOTE_ADDR" => "5.6.7.8")
+
+    refute Aikido::Zen.request_bypassed?
+  end
+
+  test ".request_bypassed? sticks once the request has been found bypassed, even if the settings change afterwards" do
+    Aikido::Zen.runtime_settings.bypassed_ips = Aikido::Zen::RuntimeSettings::IPSet.from_json(["1.2.3.4"])
+    context = Aikido::Zen.current_context = context_for("/", "REMOTE_ADDR" => "1.2.3.4")
+
+    assert Aikido::Zen.request_bypassed?
+
+    Aikido::Zen.runtime_settings.bypassed_ips = Aikido::Zen::RuntimeSettings::IPSet.new
+
+    assert Aikido::Zen.request_bypassed?
+    assert context.request_bypassed?
+  end
+
+  test ".request_bypassed! marks the current request as bypassed regardless of its IP" do
+    Aikido::Zen.current_context = context_for("/", "REMOTE_ADDR" => "5.6.7.8")
+
+    refute Aikido::Zen.request_bypassed?
+
+    Aikido::Zen.request_bypassed!
+
+    assert Aikido::Zen.request_bypassed?
+  end
+
+  test ".request_bypassed! does not fail if context is not set" do
+    assert_nil Aikido::Zen.current_context
+
+    assert_silent do
+      Aikido::Zen.request_bypassed!
+    end
+  end
+
   test ".track_user tracks the actor object in the collector" do
     users = Aikido::Zen.collector.users
 

--- a/test/rails/rails7.2_generic/app/controllers/rate_limit_controller.rb
+++ b/test/rails/rails7.2_generic/app/controllers/rate_limit_controller.rb
@@ -1,0 +1,5 @@
+class RateLimitController < ApplicationController
+  def show
+    render json: {"ok" => true}
+  end
+end

--- a/test/rails/rails7.2_generic/config/application.rb
+++ b/test/rails/rails7.2_generic/config/application.rb
@@ -9,6 +9,21 @@ Aikido::Zen.protect!
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Test-only middleware mirroring docs/request-bypassing.md's example.
+class RequestBypasser
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env["HTTP_X_BYPASS_ZEN"] == "true"
+      Aikido::Zen.request_bypassed! # Bypasses Zen for this request
+    end
+
+    @app.call(env)
+  end
+end
+
 module Generic
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -26,5 +41,9 @@ module Generic
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    initializer "generic.insert_request_bypasser", after: "aikido.add_middleware" do |app|
+      app.middleware.insert_after Aikido::Zen::Middleware::ContextSetter, RequestBypasser
+    end
   end
 end

--- a/test/rails/rails7.2_generic/config/routes.rb
+++ b/test/rails/rails7.2_generic/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", :as => :pwa_manifest
 
   get "streams" => "streams#show"
+  get "test/rate_limit" => "rate_limit#show"
 
   # Defines the root path route ("/")
   # root "posts#index"

--- a/test/rails/rails7.2_generic/test/integration/request_bypassing_test.rb
+++ b/test/rails/rails7.2_generic/test/integration/request_bypassing_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class RequestBypassingTest < ActionDispatch::IntegrationTest
+  setup do
+    Aikido::Zen.runtime_settings.update_from_runtime_config_json(
+      "endpoints" => [{
+        "method" => "GET",
+        "route" => "/test/rate_limit(.:format)",
+        "rateLimiting" => {
+          "enabled" => true,
+          "maxRequests" => 2,
+          "windowSizeInMS" => 60_000
+        }
+      }]
+    )
+  end
+
+  test "requests are rate limited normally" do
+    get "/test/rate_limit"
+    assert_response :success
+
+    get "/test/rate_limit"
+    assert_response :success
+
+    get "/test/rate_limit"
+    assert_response :too_many_requests
+  end
+
+  test "requests bypassed via Aikido::Zen.request_bypassed! are not rate limited" do
+    headers = {"X-Bypass-Zen" => "true"}
+
+    4.times do
+      get "/test/rate_limit", headers: headers
+      assert_response :success
+    end
+  end
+end


### PR DESCRIPTION
This change addresses issue #371 (enhancement).

The `Aikido::Zen.request_bypassed!` method is provided to allow existing middleware and infrastructure-specific code to make request bypassing decisions.

The feature is documented in docs/request-bypassing.md; a pseudo-example `RequestBypasser` middleware that uses this feature is created and registered.