### PR TITLE
Add missing sink stats field kind

### DIFF
--- a/lib/aikido/zen/collector.rb
+++ b/lib/aikido/zen/collector.rb
@@ -146,12 +146,12 @@ module Aikido::Zen
     # @param scan [Aikido::Zen::Scan]
     # @return [void]
     def track_scan(scan)
-      add_event(Events::TrackScan.new(scan.sink.name, scan.duration, has_errors: scan.errors?))
+      add_event(Events::TrackScan.new(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?))
     end
 
-    def handle_track_scan(sink_name, duration, has_errors:)
+    def handle_track_scan(sink_name, sink_kind, duration, has_errors:)
       synchronize(@stats) do |stats|
-        stats.add_scan(sink_name, duration, has_errors: has_errors)
+        stats.add_scan(sink_name, sink_kind, duration, has_errors: has_errors)
       end
     end
 
@@ -160,12 +160,12 @@ module Aikido::Zen
     # @param attack [Aikido::Zen::Attack]
     # @return [void]
     def track_attack(attack)
-      add_event(Events::TrackAttack.new(attack.sink.name, being_blocked: attack.blocked?))
+      add_event(Events::TrackAttack.new(attack.sink.name, attack.sink.kind, being_blocked: attack.blocked?))
     end
 
-    def handle_track_attack(sink_name, being_blocked:)
+    def handle_track_attack(sink_name, sink_kind, being_blocked:)
       synchronize(@stats) do |stats|
-        stats.add_attack(sink_name, being_blocked: being_blocked)
+        stats.add_attack(sink_name, sink_kind, being_blocked: being_blocked)
       end
     end
 

--- a/lib/aikido/zen/collector/event.rb
+++ b/lib/aikido/zen/collector/event.rb
@@ -157,14 +157,16 @@ module Aikido::Zen
         def self.from_json(data)
           new(
             data["sink_name"],
+            data["sink_kind"],
             data["duration"],
             has_errors: data["has_errors"]
           )
         end
 
-        def initialize(sink_name, duration, has_errors:)
+        def initialize(sink_name, sink_kind, duration, has_errors:)
           super()
           @sink_name = sink_name
+          @sink_kind = sink_kind
           @duration = duration
           @has_errors = has_errors
         end
@@ -172,17 +174,18 @@ module Aikido::Zen
         def as_json
           super.update({
             "sink_name" => @sink_name,
+            "sink_kind" => @sink_kind,
             "duration" => @duration,
             "has_errors" => @has_errors
           })
         end
 
         def handle(collector)
-          collector.handle_track_scan(@sink_name, @duration, has_errors: @has_errors)
+          collector.handle_track_scan(@sink_name, @sink_kind, @duration, has_errors: @has_errors)
         end
 
         def inspect
-          "#<#{self.class.name} #{@sink_name} #{format "%0.6f", @duration} #{@has_errors}>"
+          "#<#{self.class.name} #{@sink_name} #{@sink_kind} #{format "%0.6f", @duration} #{@has_errors}>"
         end
       end
 
@@ -192,29 +195,32 @@ module Aikido::Zen
         def self.from_json(data)
           new(
             data["sink_name"],
+            data["sink_kind"],
             being_blocked: data["being_blocked"]
           )
         end
 
-        def initialize(sink_name, being_blocked:)
+        def initialize(sink_name, sink_kind, being_blocked:)
           super()
           @sink_name = sink_name
+          @sink_kind = sink_kind
           @being_blocked = being_blocked
         end
 
         def as_json
           super.update({
             "sink_name" => @sink_name,
+            "sink_kind" => @sink_kind,
             "being_blocked" => @being_blocked
           })
         end
 
         def handle(collector)
-          collector.handle_track_attack(@sink_name, being_blocked: @being_blocked)
+          collector.handle_track_attack(@sink_name, @sink_kind, being_blocked: @being_blocked)
         end
 
         def inspect
-          "#<#{self.class.name} #{@sink_name} #{@being_blocked}>"
+          "#<#{self.class.name} #{@sink_name} #{@sink_kind} #{@being_blocked}>"
         end
       end
 

--- a/lib/aikido/zen/collector/sink_stats.rb
+++ b/lib/aikido/zen/collector/sink_stats.rb
@@ -7,6 +7,9 @@ module Aikido::Zen
   #
   # Tracks data specific to a single Sink.
   class Collector::SinkStats
+    # @return [String] category of operation this sink represents.
+    attr_accessor :kind
+
     # @return [Integer] number of total calls to Sink#scan.
     attr_accessor :scans
 
@@ -62,6 +65,7 @@ module Aikido::Zen
 
     def as_json
       {
+        "kind" => @kind,
         "total" => @scans,
         "interceptorThrewError" => @errors,
         "withoutContext" => 0,

--- a/lib/aikido/zen/collector/stats.rb
+++ b/lib/aikido/zen/collector/stats.rb
@@ -94,21 +94,25 @@ module Aikido::Zen
     end
 
     # @param sink_name [String] the name of the sink
+    # @param sink_kind [String] the category of operation the sink represents
     # @param duration [Float] the length the scan in seconds
     # @param has_errors [Boolean] whether errors occurred during the scan
     # @return [void]
-    def add_scan(sink_name, duration, has_errors:)
+    def add_scan(sink_name, sink_kind, duration, has_errors:)
       stats = @sinks[sink_name]
+      stats.kind = sink_kind
       stats.scans += 1
       stats.errors += 1 if has_errors
       stats.add_timing(duration)
     end
 
     # @param sink_name [String] the name of the sink
+    # @param sink_kind [String] the category of operation the sink represents
     # @param being_blocked [Boolean] whether the Agent blocked the request
     # @return [void]
-    def add_attack(sink_name, being_blocked:)
+    def add_attack(sink_name, sink_kind, being_blocked:)
       stats = @sinks[sink_name]
+      stats.kind = sink_kind
       stats.attacks += 1
       stats.blocked_attacks += 1 if being_blocked
     end

--- a/lib/aikido/zen/sink.rb
+++ b/lib/aikido/zen/sink.rb
@@ -15,6 +15,7 @@ module Aikido::Zen
     # @param name [String] name of the library being patched. (This must
     #   match the name of the gem, or we won't report that gem as
     #   supported.)
+    # @param kind [String] category of operation this sink represents.
     # @param scanners [Array<#call>] a list of objects that respond to
     #   #call with a Hash and return an Attack or nil.
     # @param opts [Hash<Symbol, Object>] any other options to pass to
@@ -23,9 +24,9 @@ module Aikido::Zen
     # @return [void]
     # @raise [ArgumentError] if a Sink with this name has already been
     #   registered.
-    def self.add(name, scanners:, **opts)
+    def self.add(name, kind, scanners:, **opts)
       raise ArgumentError, "Sink #{name} already registered" if registry.key?(name.to_s)
-      registry[name.to_s] = Sink.new(name.to_s, scanners: scanners, **opts)
+      registry[name.to_s] = Sink.new(name.to_s, kind, scanners: scanners, **opts)
     end
   end
 
@@ -42,6 +43,9 @@ module Aikido::Zen
     # @return [String] name of the patched library (e.g. "mysql2").
     attr_reader :name
 
+    # @return [String] category of operation this sink represents.
+    attr_reader :kind
+
     # @return [Array<#call>] list of registered scanners for this sink.
     attr_reader :scanners
 
@@ -53,10 +57,11 @@ module Aikido::Zen
 
     DEFAULT_REPORTER = ->(scan) { Aikido::Zen.track_scan(scan) }
 
-    def initialize(name, scanners:, operation: name, reporter: DEFAULT_REPORTER)
+    def initialize(name, kind, scanners:, operation: name, reporter: DEFAULT_REPORTER)
       raise ArgumentError, "scanners cannot be empty" if scanners.empty?
 
       @name = name
+      @kind = kind
       @operation = operation
       @scanners = scanners
       @reporter = reporter

--- a/lib/aikido/zen/sinks/async_http.rb
+++ b/lib/aikido/zen/sinks/async_http.rb
@@ -6,7 +6,7 @@ module Aikido::Zen
   module Sinks
     module Async
       module HTTP
-        SINK = Sinks.add("async-http", scanners: [
+        SINK = Sinks.add("async-http", "outgoing_http_op", scanners: [
           Scanners::SSRFScanner
         ])
 

--- a/lib/aikido/zen/sinks/curb.rb
+++ b/lib/aikido/zen/sinks/curb.rb
@@ -5,7 +5,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module Curl
-      SINK = Sinks.add("curb", scanners: [
+      SINK = Sinks.add("curb", "outgoing_http_op", scanners: [
         Scanners::SSRFScanner
       ])
 

--- a/lib/aikido/zen/sinks/em_http.rb
+++ b/lib/aikido/zen/sinks/em_http.rb
@@ -6,7 +6,7 @@ module Aikido::Zen
   module Sinks
     module EventMachine
       module HttpRequest
-        SINK = Sinks.add("em-http-request", scanners: [
+        SINK = Sinks.add("em-http-request", "outgoing_http_op", scanners: [
           Scanners::SSRFScanner
         ])
 

--- a/lib/aikido/zen/sinks/excon.rb
+++ b/lib/aikido/zen/sinks/excon.rb
@@ -5,7 +5,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module Excon
-      SINK = Sinks.add("excon", scanners: [
+      SINK = Sinks.add("excon", "outgoing_http_op", scanners: [
         Scanners::SSRFScanner
       ])
 

--- a/lib/aikido/zen/sinks/file.rb
+++ b/lib/aikido/zen/sinks/file.rb
@@ -3,7 +3,7 @@
 module Aikido::Zen
   module Sinks
     module File
-      SINK = Sinks.add("File", scanners: [Scanners::PathTraversalScanner])
+      SINK = Sinks.add("File", "fs_op", scanners: [Scanners::PathTraversalScanner])
 
       module Helpers
         def self.scan(filepath, operation)

--- a/lib/aikido/zen/sinks/http.rb
+++ b/lib/aikido/zen/sinks/http.rb
@@ -5,7 +5,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module HTTP
-      SINK = Sinks.add("http", scanners: [
+      SINK = Sinks.add("http", "outgoing_http_op", scanners: [
         Scanners::SSRFScanner
       ])
 

--- a/lib/aikido/zen/sinks/httpclient.rb
+++ b/lib/aikido/zen/sinks/httpclient.rb
@@ -5,7 +5,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module HTTPClient
-      SINK = Sinks.add("httpclient", scanners: [
+      SINK = Sinks.add("httpclient", "outgoing_http_op", scanners: [
         Scanners::SSRFScanner
       ])
 

--- a/lib/aikido/zen/sinks/httpx.rb
+++ b/lib/aikido/zen/sinks/httpx.rb
@@ -5,7 +5,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module HTTPX
-      SINK = Sinks.add("httpx", scanners: [
+      SINK = Sinks.add("httpx", "outgoing_http_op", scanners: [
         Scanners::SSRFScanner
       ])
 

--- a/lib/aikido/zen/sinks/kernel.rb
+++ b/lib/aikido/zen/sinks/kernel.rb
@@ -3,7 +3,7 @@
 module Aikido::Zen
   module Sinks
     module Kernel
-      SINK = Sinks.add("Kernel", scanners: [Scanners::ShellInjectionScanner])
+      SINK = Sinks.add("Kernel", "exec_op", scanners: [Scanners::ShellInjectionScanner])
 
       module Helpers
         def self.scan(command, operation)

--- a/lib/aikido/zen/sinks/mysql2.rb
+++ b/lib/aikido/zen/sinks/mysql2.rb
@@ -3,7 +3,7 @@
 module Aikido::Zen
   module Sinks
     module Mysql2
-      SINK = Sinks.add("mysql2", scanners: [Scanners::SQLInjectionScanner])
+      SINK = Sinks.add("mysql2", "sql_op", scanners: [Scanners::SQLInjectionScanner])
 
       module Helpers
         def self.scan(query, operation)

--- a/lib/aikido/zen/sinks/net_http.rb
+++ b/lib/aikido/zen/sinks/net_http.rb
@@ -6,7 +6,7 @@ module Aikido::Zen
   module Sinks
     module Net
       module HTTP
-        SINK = Sinks.add("net-http", scanners: [
+        SINK = Sinks.add("net-http", "outgoing_http_op", scanners: [
           Scanners::SSRFScanner
         ])
 

--- a/lib/aikido/zen/sinks/patron.rb
+++ b/lib/aikido/zen/sinks/patron.rb
@@ -5,7 +5,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module Patron
-      SINK = Sinks.add("patron", scanners: [
+      SINK = Sinks.add("patron", "outgoing_http_op", scanners: [
         Scanners::SSRFScanner
       ])
 

--- a/lib/aikido/zen/sinks/pg.rb
+++ b/lib/aikido/zen/sinks/pg.rb
@@ -3,7 +3,7 @@
 module Aikido::Zen
   module Sinks
     module PG
-      SINK = Sinks.add("pg", scanners: [Scanners::SQLInjectionScanner])
+      SINK = Sinks.add("pg", "sql_op", scanners: [Scanners::SQLInjectionScanner])
 
       module Helpers
         # For some reason, the ActiveRecord pg adaptor does not wrap exceptions

--- a/lib/aikido/zen/sinks/resolv.rb
+++ b/lib/aikido/zen/sinks/resolv.rb
@@ -6,7 +6,7 @@ require_relative "../scanners/ssrf_scanner"
 module Aikido::Zen
   module Sinks
     module Resolv
-      SINK = Sinks.add("resolv", scanners: [
+      SINK = Sinks.add("resolv", "outgoing_http_op", scanners: [
         Scanners::StoredSSRFScanner,
         Scanners::SSRFScanner
       ])

--- a/lib/aikido/zen/sinks/socket.rb
+++ b/lib/aikido/zen/sinks/socket.rb
@@ -10,7 +10,7 @@ module Aikido::Zen
     # there's no way to access the internal DNS resolution that happens in C
     # when using the socket primitives.
     module Socket
-      SINK = Sinks.add("socket", scanners: [
+      SINK = Sinks.add("socket", "outgoing_http_op", scanners: [
         Scanners::StoredSSRFScanner,
         Scanners::SSRFScanner
       ])

--- a/lib/aikido/zen/sinks/sqlite3.rb
+++ b/lib/aikido/zen/sinks/sqlite3.rb
@@ -3,7 +3,7 @@
 module Aikido::Zen
   module Sinks
     module SQLite3
-      SINK = Sinks.add("sqlite3", scanners: [Scanners::SQLInjectionScanner])
+      SINK = Sinks.add("sqlite3", "sql_op", scanners: [Scanners::SQLInjectionScanner])
 
       module Helpers
         def self.scan(query, operation)

--- a/lib/aikido/zen/sinks/trilogy.rb
+++ b/lib/aikido/zen/sinks/trilogy.rb
@@ -3,7 +3,7 @@
 module Aikido::Zen
   module Sinks
     module Trilogy
-      SINK = Sinks.add("trilogy", scanners: [Scanners::SQLInjectionScanner])
+      SINK = Sinks.add("trilogy", "sql_op", scanners: [Scanners::SQLInjectionScanner])
 
       module Helpers
         def self.scan(query, operation)

--- a/lib/aikido/zen/sinks/typhoeus.rb
+++ b/lib/aikido/zen/sinks/typhoeus.rb
@@ -5,7 +5,7 @@ require_relative "../sink"
 module Aikido::Zen
   module Sinks
     module Typhoeus
-      SINK = Sinks.add("typhoeus", scanners: [
+      SINK = Sinks.add("typhoeus", "outgoing_http_op", scanners: [
         Aikido::Zen::Scanners::SSRFScanner
       ])
 

--- a/test/aikido/zen/agent_test.rb
+++ b/test/aikido/zen/agent_test.rb
@@ -47,7 +47,7 @@ class Aikido::Zen::AgentTest < ActiveSupport::TestCase
       api_stream: @api_stream
     )
 
-    @test_sink = Aikido::Zen::Sink.new("test", scanners: [NOOP])
+    @test_sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [NOOP])
   end
 
   teardown do

--- a/test/aikido/zen/attack_test.rb
+++ b/test/aikido/zen/attack_test.rb
@@ -10,7 +10,7 @@ module Aikido::Zen
       @dialect = Aikido::Zen::SQL::Dialects.fetch(:common)
       @context = Aikido::Zen::Context.from_rack_env({})
       @op = "test.op"
-      @sink = Sink.new("test", scanners: [NOOP])
+      @sink = Sink.new("test", "sql_op", scanners: [NOOP])
     end
 
     test "keeps track of the query and triggering input" do
@@ -104,7 +104,7 @@ module Aikido::Zen
       @input = Aikido::Zen::Payload.new("localhost:7000", :body, "url")
       @context = Aikido::Zen::Context.from_rack_env({})
       @op = "net-http.request"
-      @sink = Sink.new("net-http", scanners: [NOOP])
+      @sink = Sink.new("net-http", "outgoing_http_op", scanners: [NOOP])
     end
 
     test "keeps track of the request and triggering input" do

--- a/test/aikido/zen/collector/event_test.rb
+++ b/test/aikido/zen/collector/event_test.rb
@@ -46,7 +46,7 @@ class Aikido::Zen::Collector::EventTests < ActiveSupport::TestCase
   end
 
   def stub_track_scan_event
-    TrackScan.new("sink_name", 1.0, has_errors: false)
+    TrackScan.new("test", "test_op", 1.0, has_errors: false)
   end
 
   def stub_track_scan_event_from_json(data)
@@ -54,7 +54,7 @@ class Aikido::Zen::Collector::EventTests < ActiveSupport::TestCase
   end
 
   def stub_track_attack_event
-    TrackAttack.new("sink_name", being_blocked: false)
+    TrackAttack.new("test", "test_op", being_blocked: false)
   end
 
   def stub_track_attack_event_from_json(data)
@@ -331,7 +331,8 @@ class Aikido::Zen::Collector::EventTests < ActiveSupport::TestCase
 
     assert_hash_subset_of event.as_json, {
       "type" => "track_scan",
-      "sink_name" => "sink_name",
+      "sink_name" => "test",
+      "sink_kind" => "test_op",
       "duration" => 1.0,
       "has_errors" => false
     }
@@ -358,7 +359,7 @@ class Aikido::Zen::Collector::EventTests < ActiveSupport::TestCase
     event = stub_track_scan_event
 
     collector = Minitest::Mock.new
-    collector.expect(:handle_track_scan, nil, ["sink_name", 1.0], has_errors: false)
+    collector.expect(:handle_track_scan, nil, ["test", "test_op", 1.0], has_errors: false)
 
     event.handle(collector)
 
@@ -374,7 +375,8 @@ class Aikido::Zen::Collector::EventTests < ActiveSupport::TestCase
 
     assert_hash_subset_of event.as_json, {
       "type" => "track_attack",
-      "sink_name" => "sink_name",
+      "sink_name" => "test",
+      "sink_kind" => "test_op",
       "being_blocked" => false
     }
   end
@@ -399,7 +401,7 @@ class Aikido::Zen::Collector::EventTests < ActiveSupport::TestCase
     event = stub_track_attack_event
 
     collector = Minitest::Mock.new
-    collector.expect(:handle_track_attack, nil, ["sink_name"], being_blocked: false)
+    collector.expect(:handle_track_attack, nil, ["test", "test_op"], being_blocked: false)
 
     event.handle(collector)
 

--- a/test/aikido/zen/collector/stats_test.rb
+++ b/test/aikido/zen/collector/stats_test.rb
@@ -12,8 +12,8 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
     @sink = stub_sink(name: "test")
   end
 
-  def stub_sink(name:)
-    Aikido::Zen::Sink.new(name, operation: "test", scanners: [NOOP])
+  def stub_sink(name:, kind: "test_op")
+    Aikido::Zen::Sink.new(name, kind, operation: "test", scanners: [NOOP])
   end
 
   def stub_scan(sink: @sink, context: stub_context, duration: 1, attack: nil, errors: [])
@@ -78,14 +78,14 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
   test "#empty? is false after a scan is tracked" do
     scan = stub_scan
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     refute @stats.empty?
     assert @stats.any?
   end
 
   test "#empty? is false after an attack is tracked" do
-    @stats.add_attack(@sink.name, being_blocked: true)
+    @stats.add_attack(@sink.name, @sink.kind, being_blocked: true)
     refute_empty @stats
   end
 
@@ -125,20 +125,20 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
   test "#add_scan increments the total number of scans for the sink" do
     assert_difference -> { @stats.sinks[@sink.name].scans }, +2 do
       scan = stub_scan(sink: @sink)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
       scan = stub_scan(sink: @sink)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
     end
   end
 
   test "#add_scan increments the number of errors if a scan caught an internal error" do
     assert_difference -> { @stats.sinks[@sink.name].errors }, +1 do
       scan = stub_scan(sink: @sink, errors: [RuntimeError.new])
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
       scan = stub_scan(sink: @sink)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
     end
   end
 
@@ -148,10 +148,10 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
     assert timings.empty?
 
     scan = stub_scan(sink: @sink, duration: 0.03)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink, duration: 0.05)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     assert_includes timings, 0.03
     assert_includes timings, 0.05
@@ -164,16 +164,16 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
     freeze_time do
       scan = stub_scan(sink: @sink, duration: 2)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
       scan = stub_scan(sink: @sink, duration: 3)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
       scan = stub_scan(sink: @sink, duration: 1)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
       scan = stub_scan(sink: @sink, duration: 4)
-      @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+      @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
       # The last value is kept in the raw timings list
       assert_equal Set.new([4]), stats.timings
@@ -188,15 +188,15 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
   test "#add_attack increments the total number of attacks detected for the sink" do
     assert_difference -> { @stats.sinks[@sink.name].attacks }, +2 do
-      @stats.add_attack(@sink.name, being_blocked: true)
-      @stats.add_attack(@sink.name, being_blocked: true)
+      @stats.add_attack(@sink.name, @sink.kind, being_blocked: true)
+      @stats.add_attack(@sink.name, @sink.kind, being_blocked: true)
     end
   end
 
   test "#add_attack tracks how many attacks is told were blocked per sink" do
     assert_difference -> { @stats.sinks[@sink.name].blocked_attacks }, +1 do
-      @stats.add_attack(@sink.name, being_blocked: true)
-      @stats.add_attack(@sink.name, being_blocked: false)
+      @stats.add_attack(@sink.name, @sink.kind, being_blocked: true)
+      @stats.add_attack(@sink.name, @sink.kind, being_blocked: false)
     end
   end
 
@@ -232,17 +232,18 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
   test "#as_json includes the scans grouped by sink" do
     scan = stub_scan(sink: @sink)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: stub_sink(name: "another"))
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     assert_hash_subset_of @stats.as_json, {
       "operations" => {
         "test" => {
+          "kind" => "test_op",
           "total" => 2,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -253,6 +254,7 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
           "compressedTimings" => []
         },
         "another" => {
+          "kind" => "test_op",
           "total" => 1,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -268,17 +270,18 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
   test "#as_json includes the number of scans that raised an error" do
     scan = stub_scan(sink: @sink)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink, errors: [RuntimeError.new])
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: stub_sink(name: "another"))
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     assert_hash_subset_of @stats.as_json, {
       "operations" => {
         "test" => {
+          "kind" => "test_op",
           "total" => 2,
           "interceptorThrewError" => 1,
           "withoutContext" => 0,
@@ -289,6 +292,7 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
           "compressedTimings" => []
         },
         "another" => {
+          "kind" => "test_op",
           "total" => 1,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -304,20 +308,22 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
   test "#as_json includes the attacks grouped by sink" do
     scan = stub_scan(sink: @sink)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
-    scan = stub_scan(sink: stub_sink(name: "another"))
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    another = stub_sink(name: "another")
+    scan = stub_scan(sink: another)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
-    @stats.add_attack(@sink.name, being_blocked: true)
-    @stats.add_attack("another", being_blocked: true)
+    @stats.add_attack(@sink.name, @sink.kind, being_blocked: true)
+    @stats.add_attack(another.name, another.kind, being_blocked: true)
 
     assert_hash_subset_of @stats.as_json, {
       "operations" => {
         "test" => {
+          "kind" => "test_op",
           "total" => 2,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -328,6 +334,7 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
           "compressedTimings" => []
         },
         "another" => {
+          "kind" => "test_op",
           "total" => 1,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -343,22 +350,23 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
 
   test "#as_json includes the compressed timings grouped by sink" do
     scan = stub_scan(sink: @sink, duration: 2)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink, duration: 3)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink, duration: 1)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: stub_sink(name: "another"), duration: 1)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     @stats.sinks.each_value { |s| s.compress_timings(at: Time.at(1234577890)) }
 
     assert_hash_subset_of @stats.as_json, {
       "operations" => {
         "test" => {
+          "kind" => "test_op",
           "total" => 3,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -379,6 +387,7 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
           }]
         },
         "another" => {
+          "kind" => "test_op",
           "total" => 1,
           "interceptorThrewError" => 0,
           "withoutContext" => 0,
@@ -419,13 +428,13 @@ class Aikido::Zen::Collector::StatsTest < ActiveSupport::TestCase
     compressed_timings = @stats.sinks[@sink.name].compressed_timings
 
     scan = stub_scan(sink: @sink, duration: 2)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink, duration: 3)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     scan = stub_scan(sink: @sink, duration: 1)
-    @stats.add_scan(scan.sink.name, scan.duration, has_errors: scan.errors?)
+    @stats.add_scan(scan.sink.name, scan.sink.kind, scan.duration, has_errors: scan.errors?)
 
     assert_difference -> { compressed_timings.size }, +1 do
       assert_difference -> { raw_timings.size }, -3 do

--- a/test/aikido/zen/collector_test.rb
+++ b/test/aikido/zen/collector_test.rb
@@ -321,6 +321,7 @@ class Aikido::Zen::CollectorTest < ActiveSupport::TestCase
         },
         "operations" => {
           "test" => {
+            "kind" => "test_op",
             "total" => 2,
             "interceptorThrewError" => 0,
             "withoutContext" => 0,
@@ -337,6 +338,7 @@ class Aikido::Zen::CollectorTest < ActiveSupport::TestCase
             ]
           },
           "another" => {
+            "kind" => "test_op",
             "total" => 1,
             "interceptorThrewError" => 0,
             "withoutContext" => 0,
@@ -387,6 +389,7 @@ class Aikido::Zen::CollectorTest < ActiveSupport::TestCase
         "endedAt" => 1234577890000,
         "operations" => {
           "test" => {
+            "kind" => "test_op",
             "total" => 2,
             "interceptorThrewError" => 0,
             "withoutContext" => 0,
@@ -403,6 +406,7 @@ class Aikido::Zen::CollectorTest < ActiveSupport::TestCase
             ]
           },
           "another" => {
+            "kind" => "test_op",
             "total" => 1,
             "interceptorThrewError" => 0,
             "withoutContext" => 0,
@@ -493,6 +497,7 @@ class Aikido::Zen::CollectorTest < ActiveSupport::TestCase
         "endedAt" => 1234577890000,
         "operations" => {
           "test" => {
+            "kind" => "test_op",
             "total" => 3,
             "interceptorThrewError" => 0,
             "withoutContext" => 0,
@@ -559,8 +564,8 @@ class Aikido::Zen::CollectorTest < ActiveSupport::TestCase
     }
   end
 
-  def stub_sink(name:)
-    Aikido::Zen::Sink.new(name, operation: "test", scanners: [NOOP])
+  def stub_sink(name:, kind: "test_op")
+    Aikido::Zen::Sink.new(name, kind, operation: "test", scanners: [NOOP])
   end
 
   def stub_scan(sink: @sink, context: stub_context, duration: 1, attack: nil, errors: [])

--- a/test/aikido/zen/scanners/path_traversal_scanner_test.rb
+++ b/test/aikido/zen/scanners/path_traversal_scanner_test.rb
@@ -185,7 +185,7 @@ class Aikido::Zen::Scanners::PathTraversalScannerTest < ActiveSupport::TestCase
     end
 
     def stub_sink(name:)
-      Aikido::Zen::Sink.new(name, operation: "test", scanners: [NOOP])
+      Aikido::Zen::Sink.new(name, "fs_op", operation: "test", scanners: [NOOP])
     end
 
     def stub_payload(source, value, path)

--- a/test/aikido/zen/scanners/shell_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/shell_injection_scanner_test.rb
@@ -352,7 +352,7 @@ class Aikido::Zen::Scanners::ShellInjectionScannerTest < ActiveSupport::TestCase
     end
 
     def stub_sink(name:)
-      Aikido::Zen::Sink.new(name, operation: "test", scanners: [NOOP])
+      Aikido::Zen::Sink.new(name, "exec_op", operation: "test", scanners: [NOOP])
     end
 
     def stub_payload(source, value, path)

--- a/test/aikido/zen/scanners/sql_injection_scanner_test.rb
+++ b/test/aikido/zen/scanners/sql_injection_scanner_test.rb
@@ -470,7 +470,7 @@ class Aikido::Zen::Scanners::SQLInjectionScannerTest < ActiveSupport::TestCase
     end
 
     def stub_sink(name:)
-      Aikido::Zen::Sink.new(name, operation: "test", scanners: [NOOP])
+      Aikido::Zen::Sink.new(name, "sql_op", operation: "test", scanners: [NOOP])
     end
 
     def stub_payload(source, value, path)

--- a/test/aikido/zen/sink_test.rb
+++ b/test/aikido/zen/sink_test.rb
@@ -30,7 +30,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
   NOOPScanner = FakeScanner.new { |*args, **kwargs| }
 
   test "provides access to its name and scanners" do
-    sink = Aikido::Zen::Sink.new("test", scanners: [NOOPScanner])
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [NOOPScanner])
 
     assert_equal "test", sink.name
     assert_equal [NOOPScanner], sink.scanners
@@ -38,12 +38,12 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
 
   test "does not allow initializing without scanners" do
     assert_raises ArgumentError do
-      Aikido::Zen::Sink.new("test", scanners: [])
+      Aikido::Zen::Sink.new("test", "test_op", scanners: [])
     end
   end
 
   test "scans are skipped if they don't process nil contexts and the context is nil" do
-    sink = Aikido::Zen::Sink.new("test", scanners: [
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [
       FakeScanner.new(skip_on_nil_context: true) {},
       FakeScanner.new(skip_on_nil_context: true) {},
       FakeScanner.new(skip_on_nil_context: true) {},
@@ -58,7 +58,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
   test "scans are not skipped if they don't process nil contexts and the context is not nil" do
     Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env({})
 
-    sink = Aikido::Zen::Sink.new("test", scanners: [
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [
       FakeScanner.new(skip_on_nil_context: true) {},
       FakeScanner.new(skip_on_nil_context: true) {},
       FakeScanner.new(skip_on_nil_context: true) {},
@@ -79,7 +79,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
       nil
     end
 
-    sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [scanner])
     sink.scan(foo: 1, bar: 2)
 
     assert_hash_subset_of(scan_params, {foo: 1, bar: 2, sink: sink, context: nil})
@@ -96,7 +96,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
 
     Aikido::Zen.current_context = Aikido::Zen::Context.from_rack_env({})
 
-    sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [scanner])
     sink.scan(foo: 1, bar: 2)
 
     assert_equal Aikido::Zen.current_context, scan_params[:context]
@@ -106,7 +106,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
   end
 
   test "#scan returns a Scan object" do
-    sink = Aikido::Zen::Sink.new("test", scanners: [NOOPScanner])
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [NOOPScanner])
 
     scan = sink.scan(foo: 1, bar: 2)
 
@@ -122,7 +122,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
     context.expect :scanning=, true, [true]
     context.expect :scanning=, false, [false]
 
-    sink = Aikido::Zen::Sink.new("test", reporter: NOOP, scanners: [
+    sink = Aikido::Zen::Sink.new("test", "test_op", reporter: NOOP, scanners: [
       FakeScanner.new { raise Exception, "oops" } # StandardError would be caught
     ])
 
@@ -139,7 +139,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
   # rubocop:disable Lint/RaiseException
   test "#scan stops after the first Attack is detected" do
     attack = Aikido::Zen::Attack.new(context: nil, sink: nil, operation: nil)
-    sink = Aikido::Zen::Sink.new("test", reporter: NOOP, scanners: [
+    sink = Aikido::Zen::Sink.new("test", "test_op", reporter: NOOP, scanners: [
       FakeScanner.new { attack },
       FakeScanner.new { raise Exception, "oops" } # StandardError would be caught
     ])
@@ -160,6 +160,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
 
     sink = Aikido::Zen::Sink.new(
       "test",
+      "test_op",
       scanners: [FakeScanner.new {}],
       reporter: reporter
     )
@@ -172,7 +173,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
   test "#scan captures errors raised by a scanner" do
     error = RuntimeError.new("oops")
     scanner = FakeScanner.new { raise error }
-    sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [scanner])
 
     assert_nothing_raised do
       scan = sink.scan(foo: 1, bar: 2)
@@ -184,7 +185,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
 
   test "#scan tracks how long it takes to run the scanners" do
     scanner = FakeScanner.new { sleep 0.001 and nil }
-    sink = Aikido::Zen::Sink.new("test", scanners: [scanner])
+    sink = Aikido::Zen::Sink.new("test", "test_op", scanners: [scanner])
 
     scan = sink.scan(foo: 1, bar: 2)
     assert scan.duration > 0.001
@@ -196,7 +197,7 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
 
     test "Sinks.add defines a new sink and registers it" do
       assert_changes -> { Sinks.registry.keys }, from: [], to: ["test"] do
-        sink = Sinks.add("test", scanners: [NOOPScanner])
+        sink = Sinks.add("test", "test_op", scanners: [NOOPScanner])
 
         assert_kind_of Aikido::Zen::Sink, sink
         assert_equal "test", sink.name
@@ -208,15 +209,15 @@ class Aikido::Zen::SinkTest < ActiveSupport::TestCase
       package = Aikido::Zen::Package.new("test", Gem::Version.new("1.0.0"))
       refute package.supported?
 
-      Sinks.add(package.name, scanners: [NOOPScanner])
+      Sinks.add(package.name, "test_op", scanners: [NOOPScanner])
       assert package.supported?
     end
 
     test "registering a sink more than once raises an error" do
-      Sinks.add("test", scanners: [NOOPScanner])
+      Sinks.add("test", "test_op", scanners: [NOOPScanner])
 
       assert_raises ArgumentError do
-        Sinks.add("test", scanners: [NOOPScanner])
+        Sinks.add("test", "test_op", scanners: [NOOPScanner])
       end
     end
   end

--- a/test/aikido/zen/system_info_test.rb
+++ b/test/aikido/zen/system_info_test.rb
@@ -70,8 +70,8 @@ class Aikido::Zen::InfoTest < ActiveSupport::TestCase
   test "#packages maps the list of supported loaded gems into a list of Package instances" do
     test_specs = Gem.loaded_specs.slice("concurrent-ruby", "minitest", "rack")
 
-    Aikido::Zen::Sinks.add("minitest", scanners: [NOOP])
-    Aikido::Zen::Sinks.add("concurrent-ruby", scanners: [NOOP])
+    Aikido::Zen::Sinks.add("minitest", "test_op", scanners: [NOOP])
+    Aikido::Zen::Sinks.add("concurrent-ruby", "test_op", scanners: [NOOP])
 
     Gem.stub(:loaded_specs, test_specs) do
       expected_packages = [
@@ -84,7 +84,7 @@ class Aikido::Zen::InfoTest < ActiveSupport::TestCase
   end
 
   test "as_json includes the expected fields" do
-    Aikido::Zen::Sinks.add("concurrent-ruby", scanners: [NOOP])
+    Aikido::Zen::Sinks.add("concurrent-ruby", "test_op", scanners: [NOOP])
 
     assert_equal @info.attacks_are_only_reported?, @info.as_json["dryMode"]
     assert_equal @info.library_name, @info.as_json["library"]


### PR DESCRIPTION
This change adds the missing `Aikido::Zen::Collector::SinkStats` field `kind`; threading kind it from the `Aikido::Zen::Sink`, through `Aikido::Zen::Collector` and `Aikido::Zen::Collector::Stats`. In a multiprocess deployment, the `kind` field is carried from the worker process to the main process when the `Aikido::Zen::WorkerProcess::Agent::Client#send_collector_events` as `Aikido::Zen::Collector::Events::TrackScan` and `Aikido::Zen::Collector::Events::TrackAttack` events. The appropriate closed-category of operation is provided for each kind of sink.